### PR TITLE
P0: Auto-extract action items, retry/reprocess, harden share links

### DIFF
--- a/app/(dashboard)/recordings/[recordingId]/_components/note-card.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/note-card.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { toast } from 'sonner'
+import { Sparkles } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
+import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { type Id } from '@/convex/_generated/dataModel'
 import { Card, CardContent } from '@/components/ui/card'
@@ -15,6 +17,7 @@ interface ActionItemProps {
   noteId: Id<'notes'>
   action: string
   title?: string
+  source?: 'ai' | 'manual'
   preview?: boolean
 }
 
@@ -23,6 +26,7 @@ export default function NoteCard({
   action,
   title,
   _id,
+  source,
   preview,
 }: ActionItemProps) {
   const removeActionItem = useMutation(api.notes.removeActionItem)
@@ -43,7 +47,18 @@ export default function NoteCard({
           <Checkbox onClick={handleRemoveActionItem} className="mt-0.5" />
         )}
         <div className="min-w-0 flex-1 space-y-1.5 text-start">
-          <p className="text-[15px] font-medium leading-snug">{action}</p>
+          <div className="flex items-start justify-between gap-2">
+            <p className="text-[15px] font-medium leading-snug">{action}</p>
+            {source === 'ai' && (
+              <Badge
+                variant="secondary"
+                className="shrink-0 gap-1 font-mono text-[10px] uppercase tracking-[0.1em]"
+              >
+                <Sparkles className="h-3 w-3 text-primary" />
+                AI
+              </Badge>
+            )}
+          </div>
           <p className="font-mono text-xs uppercase tracking-[0.1em] text-muted-foreground">
             {title ? `${title} · ` : ''}
             {formatDate(_creationTime)}

--- a/app/(dashboard)/recordings/_components/data-table-row-actions.tsx
+++ b/app/(dashboard)/recordings/_components/data-table-row-actions.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Ellipsis, Pencil, Share2, Trash2 } from 'lucide-react'
+import { Ellipsis, Pencil, RotateCw, Share2, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
 import { toast } from 'sonner'
@@ -21,6 +21,7 @@ import ShareNoteModal from '@/components/share-note-modal'
 export function DataTableRowActions({ id }: { id: Id<'notes'> }) {
   const router = useRouter()
   const removeNote = useMutation(api.notes.removeNote)
+  const reprocessNote = useMutation(api.notes.reprocessNote)
 
   const handleRemoveNote = () => {
     const promise = removeNote({ id })
@@ -28,6 +29,15 @@ export function DataTableRowActions({ id }: { id: Id<'notes'> }) {
       loading: 'Deleting note…',
       success: 'Note deleted',
       error: 'Failed to delete note',
+    })
+  }
+
+  const handleReprocessNote = () => {
+    const promise = reprocessNote({ id })
+    toast.promise(promise, {
+      loading: 'Restarting processing…',
+      success: 'Processing restarted',
+      error: 'Failed to restart processing',
     })
   }
 
@@ -53,6 +63,10 @@ export function DataTableRowActions({ id }: { id: Id<'notes'> }) {
             Share
           </DropdownMenuItem>
         </ShareNoteModal>
+        <DropdownMenuItem onClick={handleReprocessNote}>
+          <RotateCw className="mr-2 h-4 w-4" />
+          Reprocess
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DeleteModal onConfirm={handleRemoveNote}>
           <DropdownMenuItem

--- a/app/(public)/share/[shareId]/page.tsx
+++ b/app/(public)/share/[shareId]/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link'
 import { useQuery } from 'convex/react'
 import { useParams } from 'next/navigation'
 import { api } from '@/convex/_generated/api'
-import { type Id } from '@/convex/_generated/dataModel'
 
 import { Logo } from '@/components/logo'
 import NoteTabs from '@/components/note-tabs'
@@ -16,10 +15,10 @@ import { FileQuestion } from 'lucide-react'
 
 export default function SharePage() {
   const params = useParams()
-  const noteId = params.noteId as Id<'notes'>
+  const shareId = params.shareId as string
 
   const noteWithActionItems = useQuery(api.notes.getSharedNote, {
-    id: noteId,
+    shareId,
   })
 
   return (

--- a/components/note-tabs.tsx
+++ b/components/note-tabs.tsx
@@ -1,8 +1,12 @@
 'use client'
 
-import { Loader2, AlertCircle, ListTodo } from 'lucide-react'
-import { type Doc } from '@/convex/_generated/dataModel'
+import { toast } from 'sonner'
+import { useMutation } from 'convex/react'
+import { Loader2, AlertCircle, ListTodo, RotateCw } from 'lucide-react'
+import { api } from '@/convex/_generated/api'
+import { type Doc, type Id } from '@/convex/_generated/dataModel'
 
+import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { EmptyState } from '@/components/empty-state'
 import NoteCard from '@/app/(dashboard)/recordings/[recordingId]/_components/note-card'
@@ -23,7 +27,24 @@ function ProcessingState({ label }: { label: string }) {
   )
 }
 
-function FailedState() {
+function FailedState({
+  noteId,
+  readOnly,
+}: {
+  noteId: Id<'notes'>
+  readOnly: boolean
+}) {
+  const reprocessNote = useMutation(api.notes.reprocessNote)
+
+  const handleRetry = () => {
+    const promise = reprocessNote({ id: noteId })
+    toast.promise(promise, {
+      loading: 'Restarting processing…',
+      success: 'Processing restarted',
+      error: 'Failed to restart processing',
+    })
+  }
+
   return (
     <div className="flex flex-col items-center justify-center gap-2 rounded-xl border border-destructive/20 bg-destructive/5 py-16 text-center">
       <AlertCircle className="h-6 w-6 text-destructive" />
@@ -34,6 +55,17 @@ function FailedState() {
         The audio may have been too quiet or empty. Try recording again in a
         quiet space.
       </p>
+      {!readOnly && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleRetry}
+          className="mt-3"
+        >
+          <RotateCw className="mr-2 h-4 w-4" />
+          Retry processing
+        </Button>
+      )}
     </div>
   )
 }
@@ -50,7 +82,7 @@ export default function NoteTabs({
     content: string | undefined,
     processingLabel: string
   ) => {
-    if (isFailed) return <FailedState />
+    if (isFailed) return <FailedState noteId={note._id} readOnly={readOnly} />
     if (isProcessing) return <ProcessingState label={processingLabel} />
     return (
       <div className="rounded-xl border bg-card p-5 shadow-soft sm:p-6">

--- a/components/share-note-modal.tsx
+++ b/components/share-note-modal.tsx
@@ -2,7 +2,10 @@
 
 import { toast } from 'sonner'
 import { useState } from 'react'
-import { Check, Copy, Share2 } from 'lucide-react'
+import { useMutation } from 'convex/react'
+import { Check, Copy, Loader2, Share2 } from 'lucide-react'
+import { api } from '@/convex/_generated/api'
+import { type Id } from '@/convex/_generated/dataModel'
 import { Input } from '@/components/ui/input'
 import { useOrigin } from '@/hooks/use-origin'
 import { Button } from '@/components/ui/button'
@@ -16,7 +19,7 @@ import {
 } from '@/components/ui/dialog'
 
 interface ShareNoteModalProps {
-  noteId: string
+  noteId: Id<'notes'>
   children?: React.ReactNode
 }
 
@@ -25,11 +28,26 @@ export default function ShareNoteModal({
   children,
 }: ShareNoteModalProps) {
   const origin = useOrigin()
+  const createShareLink = useMutation(api.notes.createShareLink)
+  const [shareId, setShareId] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
 
-  const url = `${origin}/share/${noteId}`
+  const url = shareId ? `${origin}/share/${shareId}` : ''
+
+  // Generate (or fetch the existing) opaque share token when the dialog opens.
+  const onOpenChange = async (open: boolean) => {
+    if (open && !shareId) {
+      try {
+        const id = await createShareLink({ id: noteId })
+        setShareId(id)
+      } catch {
+        toast.error('Failed to create share link')
+      }
+    }
+  }
 
   const onCopy = async () => {
+    if (!url) return
     await navigator.clipboard.writeText(url)
     setCopied(true)
     toast.success('Link copied to clipboard')
@@ -37,7 +55,7 @@ export default function ShareNoteModal({
   }
 
   return (
-    <Dialog>
+    <Dialog onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
         {children ?? (
           <Button variant="outline" size="sm">
@@ -55,9 +73,20 @@ export default function ShareNoteModal({
           </DialogDescription>
         </DialogHeader>
         <div className="flex items-center gap-2">
-          <Input value={url} readOnly className="truncate" />
-          <Button onClick={onCopy} disabled={copied} className="shrink-0">
-            {copied ? (
+          <Input
+            value={url}
+            readOnly
+            placeholder="Generating link…"
+            className="truncate"
+          />
+          <Button
+            onClick={onCopy}
+            disabled={copied || !url}
+            className="shrink-0"
+          >
+            {!url ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : copied ? (
               <Check className="h-4 w-4" />
             ) : (
               <Copy className="h-4 w-4" />

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -12,5 +12,8 @@ export const TRANSCRIPTION_LANGUAGE = 'en'
 // Groq
 export const SUMMARY_MODEL = 'llama-3.3-70b-versatile'
 
+// Cap on how many action items the model may return, to bound output size.
+export const MAX_ACTION_ITEMS = 10
+
 export const SUMMARY_SYSTEM_PROMPT =
-  'You are given a transcript of a voice message. Extract a short title and a concise summary. Respond ONLY with JSON in this exact shape: {"title": "string", "summary": "string"}'
+  'You are given a transcript of a voice message. Extract a short title, a concise summary, and any concrete action items (tasks, to-dos, follow-ups) mentioned. Each action item must be a short imperative phrase. If there are no clear tasks, return an empty array. Respond ONLY with JSON in this exact shape: {"title": "string", "summary": "string", "actionItems": ["string"]}'

--- a/convex/internalMutations.ts
+++ b/convex/internalMutations.ts
@@ -27,14 +27,42 @@ export const saveSummary = internalMutation({
     noteId: v.id('notes'),
     summary: v.string(),
     title: v.string(),
+    actionItems: v.array(v.string()),
   },
   handler: async (ctx, args) => {
-    const { noteId, summary, title } = args
+    const { noteId, summary, title, actionItems } = args
+
+    const note = await ctx.db.get(noteId)
+    if (!note) return
+
     await ctx.db.patch(noteId, {
       summary,
       title,
       status: NOTE_STATUS.READY,
     })
+
+    // Clear any previously AI-generated items (e.g. on reprocess) so we don't
+    // duplicate them. Manually added items are left untouched.
+    const existing = await ctx.db
+      .query('actionItems')
+      .withIndex('by_noteId', (q) => q.eq('noteId', noteId))
+      .collect()
+    await Promise.all(
+      existing
+        .filter((item) => item.source === 'ai')
+        .map((item) => ctx.db.delete(item._id))
+    )
+
+    await Promise.all(
+      actionItems.map((action) =>
+        ctx.db.insert('actionItems', {
+          noteId,
+          userId: note.userId,
+          action,
+          source: 'ai',
+        })
+      )
+    )
   },
 })
 

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -88,13 +88,17 @@ export const getNoteById = query({
 })
 
 // Public query for the shareable note page. Intentionally unauthenticated, but
-// only ever invoked from the read-only /share route. Returns null if missing.
+// keyed by an opaque, unguessable shareId (not the raw note id) so notes can't
+// be enumerated. Returns null if the token doesn't resolve.
 export const getSharedNote = query({
   args: {
-    id: v.id('notes'),
+    shareId: v.string(),
   },
-  handler: async (ctx, { id }) => {
-    const note = await ctx.db.get(id)
+  handler: async (ctx, { shareId }) => {
+    const note = await ctx.db
+      .query('notes')
+      .withIndex('by_shareId', (q) => q.eq('shareId', shareId))
+      .unique()
     if (!note) {
       return null
     }
@@ -106,6 +110,79 @@ export const getSharedNote = query({
       .collect()
 
     return { note, actionItems }
+  },
+})
+
+// Generates (or returns the existing) opaque share token for a note. Only the
+// owner can create a link. Returns the shareId for building the public URL.
+export const createShareLink = mutation({
+  args: {
+    id: v.id('notes'),
+  },
+  handler: async (ctx, { id }) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity) {
+      throw new Error('Not authenticated')
+    }
+
+    const note = await ctx.db.get(id)
+    if (!note) {
+      throw new Error('Note not found')
+    }
+    if (note.userId !== identity.subject) {
+      throw new Error('Not your note')
+    }
+
+    if (note.shareId) {
+      return note.shareId
+    }
+
+    const shareId = crypto.randomUUID()
+    await ctx.db.patch(id, { shareId })
+    return shareId
+  },
+})
+
+// Re-runs the transcription → summarization pipeline for a note (e.g. after a
+// failure). Clears AI-generated action items first so they aren't duplicated;
+// manual items are preserved.
+export const reprocessNote = mutation({
+  args: {
+    id: v.id('notes'),
+  },
+  handler: async (ctx, { id }) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity) {
+      throw new Error('Not authenticated')
+    }
+
+    const note = await ctx.db.get(id)
+    if (!note) {
+      throw new Error('Note not found')
+    }
+    if (note.userId !== identity.subject) {
+      throw new Error('Not your note')
+    }
+    if (!note.audioFileUrl) {
+      throw new Error('This note has no audio to reprocess')
+    }
+
+    const existing = await ctx.db
+      .query('actionItems')
+      .withIndex('by_noteId', (q) => q.eq('noteId', id))
+      .collect()
+    await Promise.all(
+      existing
+        .filter((item) => item.source === 'ai')
+        .map((item) => ctx.db.delete(item._id))
+    )
+
+    await ctx.db.patch(id, { status: NOTE_STATUS.PROCESSING })
+
+    await ctx.scheduler.runAfter(0, internal.assembly.doTranscribe, {
+      fileUrl: note.audioFileUrl,
+      noteId: id,
+    })
   },
 })
 
@@ -171,6 +248,7 @@ export const createActionItem = mutation({
       userId,
       noteId,
       action,
+      source: 'manual',
     })
     return promise
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -18,11 +18,19 @@ export default defineSchema({
         v.literal('failed')
       )
     ),
-  }).index('by_userId', ['userId']),
+    // Opaque, unguessable token for the public /share route. Absent until the
+    // owner generates a share link. Existing rows have no shareId.
+    shareId: v.optional(v.string()),
+  })
+    .index('by_userId', ['userId'])
+    .index('by_shareId', ['shareId']),
   actionItems: defineTable({
     noteId: v.id('notes'),
     userId: v.string(),
     action: v.string(),
+    // Distinguishes AI-extracted items from manually added ones. Optional for
+    // migration safety: existing rows are treated as 'manual' by the UI.
+    source: v.optional(v.union(v.literal('ai'), v.literal('manual'))),
   })
     .index('by_noteId', ['noteId'])
     .index('by_userId', ['userId']),

--- a/convex/summarize.ts
+++ b/convex/summarize.ts
@@ -4,12 +4,28 @@ import { v } from 'convex/values'
 import Groq from 'groq-sdk'
 import { internal } from './_generated/api'
 import { requireEnv } from './env'
-import { SUMMARY_MODEL, SUMMARY_SYSTEM_PROMPT } from './constants'
+import {
+  MAX_ACTION_ITEMS,
+  SUMMARY_MODEL,
+  SUMMARY_SYSTEM_PROMPT,
+} from './constants'
 import { internalAction } from './_generated/server'
 
 interface TranscriptSummary {
   title: string
   summary: string
+  actionItems: string[]
+}
+
+// Defensively coerce the model's actionItems field into a clean string[]:
+// guard the type, trim, drop blanks, dedupe, and cap the length.
+function parseActionItems(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const cleaned = value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+  return [...new Set(cleaned)].slice(0, MAX_ACTION_ITEMS)
 }
 
 export const chat = internalAction({
@@ -39,6 +55,7 @@ export const chat = internalAction({
         noteId,
         title: data.title?.trim() || 'Untitled note',
         summary: data.summary?.trim() || 'No summary available.',
+        actionItems: parseActionItems(data.actionItems),
       })
     } catch (error) {
       console.error('Summarization failed:', error)


### PR DESCRIPTION
## P0 — Core fixes

First phase of the feature roadmap. Closes the gap between what the landing page promises and what ships, plus a share-link security fix.

### 🤖 Auto-extracted action items
The landing page claims to-dos are extracted automatically — now they actually are. The Groq summarize step returns `{title, summary, actionItems[]}`; items are parsed defensively (type-guarded, trimmed, deduped, capped at `MAX_ACTION_ITEMS`) and stored as `actionItems` rows tagged `source: 'ai'`, shown with an ✨ AI badge. Manual add is unchanged.

### 🔁 Retry / reprocess
New `reprocessNote` mutation re-runs the transcription → summarization pipeline from the stored `audioFileUrl`. Clears prior **AI** items to avoid duplicates, preserves manual ones. Surfaced as a "Retry processing" button in the failed state and a "Reprocess" row action.

### 🔒 Share-link hardening
Notes now get an opaque `shareId` token (`createShareLink`); `getSharedNote` is keyed by token via a new `by_shareId` index instead of the raw, enumerable note id. Route renamed `/share/[noteId]` → `/share/[shareId]`.

### Notes
- All new schema fields are optional → no migration; `convex codegen` validated against the live deployment.
- ✅ `tsc --noEmit` and `next build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)