### PR TITLE
P1: Inline edit of note fields + audio playback

### DIFF
--- a/app/(dashboard)/recordings/[recordingId]/_components/audio-player.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/audio-player.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { forwardRef, useRef, useState } from 'react'
+import { Pause, Play } from 'lucide-react'
+
+import { cn, formatDuration } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+
+interface AudioPlayerProps {
+  src: string
+  className?: string
+}
+
+// Styled wrapper around a native <audio> element. Forwards the underlying
+// element ref so callers (e.g. transcript click-to-seek in a later phase) can
+// drive playback position.
+export const AudioPlayer = forwardRef<HTMLAudioElement, AudioPlayerProps>(
+  function AudioPlayer({ src, className }, externalRef) {
+    const internalRef = useRef<HTMLAudioElement | null>(null)
+    const [isPlaying, setIsPlaying] = useState(false)
+    const [currentTime, setCurrentTime] = useState(0)
+    const [duration, setDuration] = useState(0)
+
+    const setRefs = (el: HTMLAudioElement | null) => {
+      internalRef.current = el
+      if (typeof externalRef === 'function') externalRef(el)
+      else if (externalRef) externalRef.current = el
+    }
+
+    const togglePlay = () => {
+      const audio = internalRef.current
+      if (!audio) return
+      if (audio.paused) void audio.play()
+      else audio.pause()
+    }
+
+    const onSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const audio = internalRef.current
+      if (!audio) return
+      const next = Number(e.target.value)
+      audio.currentTime = next
+      setCurrentTime(next)
+    }
+
+    return (
+      <div
+        className={cn(
+          'flex items-center gap-3 rounded-xl border bg-card p-3 shadow-soft',
+          className
+        )}
+      >
+        <Button
+          type="button"
+          size="icon"
+          onClick={togglePlay}
+          aria-label={isPlaying ? 'Pause' : 'Play'}
+          className="h-10 w-10 shrink-0 rounded-full"
+        >
+          {isPlaying ? (
+            <Pause className="h-4 w-4" />
+          ) : (
+            <Play className="h-4 w-4 translate-x-px" />
+          )}
+        </Button>
+
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <input
+            type="range"
+            min={0}
+            max={duration || 0}
+            step="any"
+            value={currentTime}
+            onChange={onSeek}
+            aria-label="Seek"
+            className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
+          />
+          <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+            {formatDuration(currentTime)} / {formatDuration(duration)}
+          </span>
+        </div>
+
+        <audio
+          ref={setRefs}
+          src={src}
+          preload="metadata"
+          onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}
+          onTimeUpdate={(e) => setCurrentTime(e.currentTarget.currentTime)}
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+          onEnded={() => setIsPlaying(false)}
+        />
+      </div>
+    )
+  }
+)

--- a/app/(dashboard)/recordings/[recordingId]/_components/editable-field.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/editable-field.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { toast } from 'sonner'
+import { useState } from 'react'
+import { useMutation } from 'convex/react'
+import { Check, Pencil, X } from 'lucide-react'
+import { api } from '@/convex/_generated/api'
+import { type Id } from '@/convex/_generated/dataModel'
+
+import { cn } from '@/lib/utils'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+
+interface EditableFieldProps {
+  noteId: Id<'notes'>
+  field: 'title' | 'summary' | 'transcription'
+  value: string
+  multiline?: boolean
+  placeholder?: string
+  // Classes applied to the read-mode text (lets the title look like a heading
+  // and the body look like prose).
+  className?: string
+}
+
+export function EditableField({
+  noteId,
+  field,
+  value,
+  multiline = false,
+  placeholder = 'Nothing here yet.',
+  className,
+}: EditableFieldProps) {
+  const updateNoteFields = useMutation(api.notes.updateNoteFields)
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const startEditing = () => {
+    setDraft(value)
+    setIsEditing(true)
+  }
+
+  const handleSave = async () => {
+    if (field === 'title' && draft.trim().length === 0) {
+      toast.error('Title can’t be empty')
+      return
+    }
+    setIsSaving(true)
+    try {
+      await updateNoteFields({ id: noteId, [field]: draft })
+      toast.success('Saved')
+      setIsEditing(false)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (isEditing) {
+    return (
+      <div className="space-y-2">
+        {multiline ? (
+          <Textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            disabled={isSaving}
+            autoFocus
+            rows={8}
+            className="text-[15px] leading-relaxed"
+          />
+        ) : (
+          <Input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            disabled={isSaving}
+            autoFocus
+            className="text-lg font-medium"
+          />
+        )}
+        <div className="flex items-center gap-2">
+          <Button size="sm" onClick={handleSave} disabled={isSaving}>
+            <Check className="mr-1.5 h-4 w-4" />
+            {isSaving ? 'Saving…' : 'Save'}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setIsEditing(false)}
+            disabled={isSaving}
+          >
+            <X className="mr-1.5 h-4 w-4" />
+            Cancel
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const hasValue = value.trim().length > 0
+  const Tag = multiline ? 'div' : 'h1'
+
+  return (
+    <div className="group/edit relative flex items-start gap-2">
+      <Tag
+        className={cn(
+          'min-w-0 flex-1 whitespace-pre-wrap',
+          !hasValue && 'text-muted-foreground',
+          className
+        )}
+      >
+        {hasValue ? value : placeholder}
+      </Tag>
+      <Button
+        size="icon"
+        variant="ghost"
+        onClick={startEditing}
+        aria-label={`Edit ${field}`}
+        className="h-7 w-7 shrink-0 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover/edit:opacity-100"
+      >
+        <Pencil className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  )
+}

--- a/app/(dashboard)/recordings/[recordingId]/page.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/page.tsx
@@ -12,6 +12,8 @@ import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/status-badge'
 import { ActionItemSkeleton } from '@/components/skeletons'
 import ShareNoteModal from '@/components/share-note-modal'
+import { AudioPlayer } from './_components/audio-player'
+import { EditableField } from './_components/editable-field'
 
 export default function RecordingIdPage() {
   const params = useParams()
@@ -51,16 +53,26 @@ export default function RecordingIdPage() {
         </Link>
       </Button>
 
-      <div className="mb-8 flex items-start justify-between gap-4">
-        <div className="space-y-3">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1 space-y-3">
           <p className="eyebrow">Recording</p>
-          <h1 className="text-3xl font-medium tracking-tight sm:text-4xl">
-            {note.title ?? 'Untitled note'}
-          </h1>
+          <EditableField
+            noteId={note._id}
+            field="title"
+            value={note.title ?? ''}
+            placeholder="Untitled note"
+            className="text-3xl font-medium tracking-tight sm:text-4xl"
+          />
           <StatusBadge status={status} />
         </div>
         <ShareNoteModal noteId={note._id} />
       </div>
+
+      {note.audioFileUrl && (
+        <div className="mb-8">
+          <AudioPlayer src={note.audioFileUrl} />
+        </div>
+      )}
 
       <NoteTabs note={note} actionItems={actionItems} />
     </div>

--- a/components/note-tabs.tsx
+++ b/components/note-tabs.tsx
@@ -11,6 +11,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { EmptyState } from '@/components/empty-state'
 import NoteCard from '@/app/(dashboard)/recordings/[recordingId]/_components/note-card'
 import ActionForm from '@/app/(dashboard)/recordings/[recordingId]/_components/action-form'
+import { EditableField } from '@/app/(dashboard)/recordings/[recordingId]/_components/editable-field'
 
 interface NoteTabsProps {
   note: Doc<'notes'>
@@ -79,6 +80,7 @@ export default function NoteTabs({
   const isFailed = note.status === 'failed'
 
   const renderContent = (
+    field: 'transcription' | 'summary',
     content: string | undefined,
     processingLabel: string
   ) => {
@@ -86,9 +88,19 @@ export default function NoteTabs({
     if (isProcessing) return <ProcessingState label={processingLabel} />
     return (
       <div className="rounded-xl border bg-card p-5 shadow-soft sm:p-6">
-        <div className="whitespace-pre-wrap text-left text-[15px] leading-relaxed text-foreground/90">
-          {content && content.length > 0 ? content : 'Nothing here yet.'}
-        </div>
+        {readOnly ? (
+          <div className="whitespace-pre-wrap text-left text-[15px] leading-relaxed text-foreground/90">
+            {content && content.length > 0 ? content : 'Nothing here yet.'}
+          </div>
+        ) : (
+          <EditableField
+            noteId={note._id}
+            field={field}
+            value={content ?? ''}
+            multiline
+            className="text-left text-[15px] leading-relaxed text-foreground/90"
+          />
+        )}
       </div>
     )
   }
@@ -102,11 +114,15 @@ export default function NoteTabs({
       </TabsList>
 
       <TabsContent value="transcript" className="mt-6">
-        {renderContent(note.transcription, 'Transcribing your audio…')}
+        {renderContent(
+          'transcription',
+          note.transcription,
+          'Transcribing your audio…'
+        )}
       </TabsContent>
 
       <TabsContent value="summary" className="mt-6">
-        {renderContent(note.summary, 'Generating your summary…')}
+        {renderContent('summary', note.summary, 'Generating your summary…')}
       </TabsContent>
 
       <TabsContent value="actionItem" className="mt-6 space-y-4">

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = 'Textarea'
+
+export { Textarea }

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -186,6 +186,45 @@ export const reprocessNote = mutation({
   },
 })
 
+// Lets the owner correct AI output by editing the note's text fields. Only the
+// fields provided are patched; an empty/blank title is ignored to avoid wiping
+// it. Used by the inline editors on the recording detail page.
+export const updateNoteFields = mutation({
+  args: {
+    id: v.id('notes'),
+    title: v.optional(v.string()),
+    summary: v.optional(v.string()),
+    transcription: v.optional(v.string()),
+  },
+  handler: async (ctx, { id, title, summary, transcription }) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity) {
+      throw new Error('Not authenticated')
+    }
+
+    const note = await ctx.db.get(id)
+    if (!note) {
+      throw new Error('Note not found')
+    }
+    if (note.userId !== identity.subject) {
+      throw new Error('Not your note')
+    }
+
+    const patch: {
+      title?: string
+      summary?: string
+      transcription?: string
+    } = {}
+    if (title !== undefined && title.trim().length > 0) {
+      patch.title = title.trim()
+    }
+    if (summary !== undefined) patch.summary = summary
+    if (transcription !== undefined) patch.transcription = transcription
+
+    await ctx.db.patch(id, patch)
+  },
+})
+
 export const removeNote = mutation({
   args: {
     id: v.id('notes'),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -22,6 +22,17 @@ export function formatTime(time: number): string {
   return time < 10 ? `0${time}` : `${time}`
 }
 
+// Formats a number of seconds as m:ss (or h:mm:ss) for an audio player readout.
+export function formatDuration(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) return '0:00'
+  const seconds = Math.floor(totalSeconds % 60)
+  const minutes = Math.floor((totalSeconds / 60) % 60)
+  const hours = Math.floor(totalSeconds / 3600)
+  const mm = hours > 0 ? formatTime(minutes) : `${minutes}`
+  if (hours > 0) return `${hours}:${formatTime(minutes)}:${formatTime(seconds)}`
+  return `${mm}:${formatTime(seconds)}`
+}
+
 export function formatDate(timestamp: number) {
   const date = new Date(timestamp)
   const options: Intl.DateTimeFormatOptions = {


### PR DESCRIPTION
## P1 — Edit & playback

Builds on #5 (P0). Makes notes editable and finally lets you hear your recordings.

### ✏️ Inline edit
New `updateNoteFields` mutation (owner-guarded; patches only the fields provided; ignores a blank title). A reusable `EditableField` component shows an inline editor behind a hover pencil — `Input` for the title, `Textarea` for the body — wired into:
- the detail-page **title**
- the **transcript** and **summary** tabs

The read-only `/share` view keeps its static, non-editable render.

### 🔊 Audio playback
New `AudioPlayer` — styled controls over a native `<audio>`: play/pause, a scrubber, and an `m:ss / m:ss` readout (new `formatDuration` helper). Rendered above the tabs on the detail page from the stored `audioFileUrl`. The underlying element ref is forwarded so P3 can add click-a-word-to-seek.

### Notes
- Added a shadcn `Textarea` primitive.
- ✅ `tsc --noEmit` and `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)