### PR TITLE
P2: Full-text search + Ask-your-notes

### DIFF
--- a/app/(dashboard)/ask/page.tsx
+++ b/app/(dashboard)/ask/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { ChatPanel } from '@/components/chat-panel'
+import { PageHeader } from '@/components/page-header'
+
+export default function AskPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col px-4 py-8 sm:px-6">
+      <PageHeader
+        eyebrow="Ask"
+        title="Ask your notes"
+        subtitle="Ask a question and get an answer drawn from across all your recordings."
+        className="mb-8"
+      />
+
+      <div className="h-[32rem] rounded-xl border bg-card p-4 shadow-soft sm:p-5">
+        <ChatPanel
+          placeholder="Ask anything about your notes…"
+          emptyHint="Ask anything — “What did I decide about the budget?”, “Summarize my meetings this week.” Answers cite the notes they came from."
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/(dashboard)/search/page.tsx
+++ b/app/(dashboard)/search/page.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { useQuery } from 'convex/react'
+import { FileText, Search as SearchIcon } from 'lucide-react'
+import { api } from '@/convex/_generated/api'
+
+import { formatDate } from '@/lib/utils'
+import { Input } from '@/components/ui/input'
+import { PageHeader } from '@/components/page-header'
+import { EmptyState } from '@/components/empty-state'
+import { StatusBadge } from '@/components/status-badge'
+
+export default function SearchPage() {
+  const [query, setQuery] = useState('')
+  const [debounced, setDebounced] = useState('')
+
+  // Debounce so we don't fire a search query on every keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query.trim()), 250)
+    return () => clearTimeout(t)
+  }, [query])
+
+  const results = useQuery(
+    api.notes.searchNotes,
+    debounced.length > 0 ? { query: debounced } : 'skip'
+  )
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-8 sm:px-6">
+      <PageHeader
+        eyebrow="Find"
+        title="Search"
+        subtitle="Search across the titles, summaries, and transcripts of your notes."
+        className="mb-8"
+      />
+
+      <div className="relative">
+        <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search your notes…"
+          className="pl-9"
+          autoFocus
+        />
+      </div>
+
+      <div className="mt-6">
+        {debounced.length === 0 ? (
+          <EmptyState
+            icon={SearchIcon}
+            title="Search your notes"
+            description="Start typing to find a recording by anything that was said in it."
+          />
+        ) : results === undefined ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            Searching…
+          </p>
+        ) : results.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No notes match “{debounced}”.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {results.map((note) => (
+              <Link
+                key={note._id}
+                href={`/recordings/${note._id}`}
+                className="group block rounded-xl border bg-card p-4 shadow-soft transition-all hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-soft-lg"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex min-w-0 items-start gap-3">
+                    <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-primary/20 bg-accent text-primary">
+                      <FileText className="h-4 w-4" />
+                    </span>
+                    <div className="min-w-0 space-y-1">
+                      <p className="truncate font-display text-[15px] font-medium">
+                        {note.title ?? 'Untitled note'}
+                      </p>
+                      {note.summary && (
+                        <p className="line-clamp-2 text-sm text-muted-foreground">
+                          {note.summary}
+                        </p>
+                      )}
+                      <p className="font-mono text-xs uppercase tracking-[0.1em] text-muted-foreground">
+                        {formatDate(note._creationTime)}
+                      </p>
+                    </div>
+                  </div>
+                  <StatusBadge status={note.status ?? 'ready'} />
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import Link from 'next/link'
+import { toast } from 'sonner'
+import { useEffect, useRef, useState } from 'react'
+import { useMutation, useQuery } from 'convex/react'
+import { ArrowUp, FileText, Loader2, Sparkles } from 'lucide-react'
+import { api } from '@/convex/_generated/api'
+import { type Id } from '@/convex/_generated/dataModel'
+
+import { cn } from '@/lib/utils'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+interface ChatPanelProps {
+  // Omit for the all-notes thread; pass a note id to scope the chat to one note.
+  noteId?: Id<'notes'>
+  placeholder?: string
+  emptyHint?: string
+}
+
+export function ChatPanel({
+  noteId,
+  placeholder = 'Ask a question…',
+  emptyHint = 'Ask anything about your notes.',
+}: ChatPanelProps) {
+  const getOrCreateThread = useMutation(api.chat.getOrCreateThread)
+  const ask = useMutation(api.chat.ask)
+
+  const [threadId, setThreadId] = useState<Id<'chatThreads'> | null>(null)
+  const [input, setInput] = useState('')
+  const [sending, setSending] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  // Resolve (or create) the thread for this scope once.
+  useEffect(() => {
+    let active = true
+    getOrCreateThread({ noteId })
+      .then((id) => {
+        if (active) setThreadId(id)
+      })
+      .catch(() => toast.error('Could not start the chat'))
+    return () => {
+      active = false
+    }
+  }, [getOrCreateThread, noteId])
+
+  const messages = useQuery(
+    api.chat.listMessages,
+    threadId ? { threadId } : 'skip'
+  )
+
+  const lastIsUser =
+    messages && messages.length > 0
+      ? messages[messages.length - 1]?.role === 'user'
+      : false
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages?.length, lastIsUser])
+
+  const handleSend = async () => {
+    const message = input.trim()
+    if (!message || !threadId || sending) return
+    setSending(true)
+    setInput('')
+    try {
+      await ask({ threadId, message })
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to send')
+      setInput(message)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const loading = messages === undefined || threadId === null
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 space-y-4 overflow-y-auto">
+        {loading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : messages.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+            <span className="flex h-12 w-12 items-center justify-center rounded-xl border border-primary/20 bg-accent text-primary">
+              <Sparkles className="h-6 w-6" />
+            </span>
+            <p className="max-w-xs text-sm text-muted-foreground">{emptyHint}</p>
+          </div>
+        ) : (
+          messages.map((m) => (
+            <div
+              key={m._id}
+              className={cn(
+                'flex',
+                m.role === 'user' ? 'justify-end' : 'justify-start'
+              )}
+            >
+              <div
+                className={cn(
+                  'max-w-[85%] space-y-2 rounded-2xl px-4 py-2.5 text-[15px] leading-relaxed',
+                  m.role === 'user'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'border bg-card'
+                )}
+              >
+                <p className="whitespace-pre-wrap">{m.content}</p>
+                {m.citedNoteIds && m.citedNoteIds.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 pt-1">
+                    {m.citedNoteIds.map((id, i) => (
+                      <Link
+                        key={id}
+                        href={`/recordings/${id}`}
+                        className="inline-flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+                      >
+                        <FileText className="h-3 w-3" />
+                        Source {i + 1}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+
+        {lastIsUser && (
+          <div className="flex justify-start">
+            <div className="flex items-center gap-2 rounded-2xl border bg-card px-4 py-2.5 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Thinking…
+            </div>
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      <form
+        action={handleSend}
+        className="mt-4 flex items-center gap-2 border-t pt-4"
+      >
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={placeholder}
+          disabled={loading}
+        />
+        <Button
+          type="submit"
+          size="icon"
+          disabled={loading || sending || input.trim().length === 0}
+          className="shrink-0 rounded-full"
+          aria-label="Send"
+        >
+          <ArrowUp className="h-4 w-4" />
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/components/note-tabs.tsx
+++ b/components/note-tabs.tsx
@@ -6,7 +6,9 @@ import { Loader2, AlertCircle, ListTodo, RotateCw } from 'lucide-react'
 import { api } from '@/convex/_generated/api'
 import { type Doc, type Id } from '@/convex/_generated/dataModel'
 
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { ChatPanel } from '@/components/chat-panel'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { EmptyState } from '@/components/empty-state'
 import NoteCard from '@/app/(dashboard)/recordings/[recordingId]/_components/note-card'
@@ -107,10 +109,16 @@ export default function NoteTabs({
 
   return (
     <Tabs defaultValue="transcript" className="w-full">
-      <TabsList className="grid h-11 w-full grid-cols-3 border">
+      <TabsList
+        className={cn(
+          'grid h-11 w-full border',
+          readOnly ? 'grid-cols-3' : 'grid-cols-4'
+        )}
+      >
         <TabsTrigger value="transcript">Transcript</TabsTrigger>
         <TabsTrigger value="summary">Summary</TabsTrigger>
         <TabsTrigger value="actionItem">Action Items</TabsTrigger>
+        {!readOnly && <TabsTrigger value="ask">Ask</TabsTrigger>}
       </TabsList>
 
       <TabsContent value="transcript" className="mt-6">
@@ -148,6 +156,18 @@ export default function NoteTabs({
           />
         )}
       </TabsContent>
+
+      {!readOnly && (
+        <TabsContent value="ask" className="mt-6">
+          <div className="h-[28rem] rounded-xl border bg-card p-4 shadow-soft sm:p-5">
+            <ChatPanel
+              noteId={note._id}
+              placeholder="Ask about this recording…"
+              emptyHint="Ask anything about this recording — what was decided, who said what, key points."
+            />
+          </div>
+        </TabsContent>
+      )}
     </Tabs>
   )
 }

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -8,6 +8,14 @@ export const navItems = [
     href: '/record',
   },
   {
+    title: 'Ask',
+    href: '/ask',
+  },
+  {
+    title: 'Search',
+    href: '/search',
+  },
+  {
     title: 'Action Items',
     href: '/action-items',
   },

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,9 @@
  */
 
 import type * as assembly from "../assembly.js";
+import type * as backfill from "../backfill.js";
+import type * as chat from "../chat.js";
+import type * as chatAnswer from "../chatAnswer.js";
 import type * as constants from "../constants.js";
 import type * as env from "../env.js";
 import type * as internalMutations from "../internalMutations.js";
@@ -23,6 +26,9 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   assembly: typeof assembly;
+  backfill: typeof backfill;
+  chat: typeof chat;
+  chatAnswer: typeof chatAnswer;
   constants: typeof constants;
   env: typeof env;
   internalMutations: typeof internalMutations;

--- a/convex/backfill.ts
+++ b/convex/backfill.ts
@@ -1,0 +1,25 @@
+import { buildSearchBlob } from './constants'
+import { internalMutation } from './_generated/server'
+
+// One-shot maintenance: populate searchBlob for notes created before full-text
+// search existed, so they become findable by /search and Ask-your-notes.
+// Run once with: npx convex run backfill:backfillSearchBlob
+export const backfillSearchBlob = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const notes = await ctx.db.query('notes').collect()
+    let updated = 0
+    for (const note of notes) {
+      const blob = buildSearchBlob({
+        title: note.title,
+        summary: note.summary,
+        transcription: note.transcription,
+      })
+      if (blob !== (note.searchBlob ?? '')) {
+        await ctx.db.patch(note._id, { searchBlob: blob })
+        updated++
+      }
+    }
+    return { scanned: notes.length, updated }
+  },
+})

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -1,0 +1,169 @@
+import { v } from 'convex/values'
+import { internal } from './_generated/api'
+import {
+  ASK_RETRIEVAL_LIMIT,
+  ASK_TRANSCRIPT_CHAR_LIMIT,
+} from './constants'
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from './_generated/server'
+
+// Returns the existing thread for the given scope, creating it if needed.
+// noteId set = a thread scoped to one note; noteId absent = the user's single
+// all-notes thread.
+export const getOrCreateThread = mutation({
+  args: {
+    noteId: v.optional(v.id('notes')),
+  },
+  handler: async (ctx, { noteId }) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity) {
+      throw new Error('Not authenticated')
+    }
+    const userId = identity.subject
+
+    if (noteId) {
+      const note = await ctx.db.get(noteId)
+      if (!note || note.userId !== userId) {
+        throw new Error('Not your note')
+      }
+      const existing = await ctx.db
+        .query('chatThreads')
+        .withIndex('by_noteId', (q) => q.eq('noteId', noteId))
+        .filter((q) => q.eq(q.field('userId'), userId))
+        .first()
+      if (existing) return existing._id
+      return await ctx.db.insert('chatThreads', { userId, noteId })
+    }
+
+    // All-notes thread: the one thread for this user with no noteId.
+    const threads = await ctx.db
+      .query('chatThreads')
+      .withIndex('by_userId', (q) => q.eq('userId', userId))
+      .collect()
+    const allNotes = threads.find((t) => t.noteId === undefined)
+    if (allNotes) return allNotes._id
+    return await ctx.db.insert('chatThreads', { userId })
+  },
+})
+
+export const listMessages = query({
+  args: {
+    threadId: v.id('chatThreads'),
+  },
+  handler: async (ctx, { threadId }) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity) {
+      throw new Error('Not authenticated')
+    }
+    const thread = await ctx.db.get(threadId)
+    if (!thread || thread.userId !== identity.subject) {
+      return []
+    }
+    return await ctx.db
+      .query('chatMessages')
+      .withIndex('by_threadId', (q) => q.eq('threadId', threadId))
+      .order('asc')
+      .collect()
+  },
+})
+
+// Records the user's message and schedules the assistant's reply (a Node
+// action, since it calls Groq).
+export const ask = mutation({
+  args: {
+    threadId: v.id('chatThreads'),
+    message: v.string(),
+  },
+  handler: async (ctx, { threadId, message }) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity) {
+      throw new Error('Not authenticated')
+    }
+    const userId = identity.subject
+    const thread = await ctx.db.get(threadId)
+    if (!thread || thread.userId !== userId) {
+      throw new Error('Not your thread')
+    }
+    const trimmed = message.trim()
+    if (trimmed.length === 0) {
+      throw new Error('Message is empty')
+    }
+
+    await ctx.db.insert('chatMessages', {
+      threadId,
+      userId,
+      role: 'user',
+      content: trimmed,
+    })
+
+    await ctx.scheduler.runAfter(0, internal.chatAnswer.answer, {
+      threadId,
+      message: trimmed,
+    })
+  },
+})
+
+// Internal: gathers the note transcripts that should ground the answer. For a
+// note-scoped thread that's just the one note; for the all-notes thread it's a
+// full-text retrieval over the question.
+export const getThreadContext = internalQuery({
+  args: {
+    threadId: v.id('chatThreads'),
+    query: v.string(),
+  },
+  handler: async (ctx, { threadId, query: question }) => {
+    const thread = await ctx.db.get(threadId)
+    if (!thread) return null
+    const userId = thread.userId
+    const scoped = thread.noteId !== undefined
+
+    let notes
+    if (thread.noteId) {
+      const note = await ctx.db.get(thread.noteId)
+      notes = note ? [note] : []
+    } else {
+      const trimmed = question.trim()
+      notes =
+        trimmed.length > 0
+          ? await ctx.db
+              .query('notes')
+              .withSearchIndex('search_blob', (q) =>
+                q.search('searchBlob', trimmed).eq('userId', userId)
+              )
+              .take(ASK_RETRIEVAL_LIMIT)
+          : []
+    }
+
+    const context = notes
+      .filter((n) => n.transcription && n.transcription.trim().length > 0)
+      .map((n) => ({
+        noteId: n._id,
+        title: n.title ?? 'Untitled note',
+        text: (n.transcription ?? '').slice(0, ASK_TRANSCRIPT_CHAR_LIMIT),
+      }))
+
+    return { userId, scoped, context }
+  },
+})
+
+export const saveAnswer = internalMutation({
+  args: {
+    threadId: v.id('chatThreads'),
+    userId: v.string(),
+    content: v.string(),
+    citedNoteIds: v.array(v.id('notes')),
+  },
+  handler: async (ctx, { threadId, userId, content, citedNoteIds }) => {
+    await ctx.db.insert('chatMessages', {
+      threadId,
+      userId,
+      role: 'assistant',
+      content,
+      citedNoteIds,
+    })
+  },
+})

--- a/convex/chatAnswer.ts
+++ b/convex/chatAnswer.ts
@@ -1,0 +1,76 @@
+'use node'
+
+import { v } from 'convex/values'
+import Groq from 'groq-sdk'
+import { internal } from './_generated/api'
+import { type Id } from './_generated/dataModel'
+import { requireEnv } from './env'
+import { ASK_SYSTEM_PROMPT, SUMMARY_MODEL } from './constants'
+import { internalAction } from './_generated/server'
+
+// Generates the assistant reply for a thread: pulls grounding transcripts,
+// asks Groq, and saves the answer. Runs in Node because it calls the Groq SDK.
+export const answer = internalAction({
+  args: {
+    threadId: v.id('chatThreads'),
+    message: v.string(),
+  },
+  handler: async (ctx, { threadId, message }) => {
+    const data = await ctx.runQuery(internal.chat.getThreadContext, {
+      threadId,
+      query: message,
+    })
+    if (!data) return
+
+    let content: string
+    let citedNoteIds: Id<'notes'>[] = []
+
+    try {
+      if (data.context.length === 0) {
+        content = data.scoped
+          ? "This note doesn't have a transcript yet, so I can't answer questions about it."
+          : "I couldn't find anything in your notes that answers that."
+      } else {
+        const contextText = data.context
+          .map((c, i) => `Note ${i + 1} — "${c.title}":\n${c.text}`)
+          .join('\n\n---\n\n')
+
+        const groq = new Groq({ apiKey: requireEnv('GROQ_API_KEY') })
+        const completion = await groq.chat.completions.create({
+          model: SUMMARY_MODEL,
+          messages: [
+            { role: 'system', content: ASK_SYSTEM_PROMPT },
+            {
+              role: 'user',
+              content: `Note context:\n${contextText}\n\nQuestion: ${message}`,
+            },
+          ],
+        })
+
+        content =
+          completion.choices[0]?.message?.content?.trim() ||
+          "I couldn't generate an answer."
+        // Only surface citations for all-notes answers; a note-scoped thread
+        // is already about a single, known note.
+        if (!data.scoped) {
+          citedNoteIds = data.context.map((c) => c.noteId)
+        }
+      }
+
+      await ctx.runMutation(internal.chat.saveAnswer, {
+        threadId,
+        userId: data.userId,
+        content,
+        citedNoteIds,
+      })
+    } catch (error) {
+      console.error('Ask failed:', error)
+      await ctx.runMutation(internal.chat.saveAnswer, {
+        threadId,
+        userId: data.userId,
+        content: 'Something went wrong answering that. Please try again.',
+        citedNoteIds: [],
+      })
+    }
+  },
+})

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -17,3 +17,25 @@ export const MAX_ACTION_ITEMS = 10
 
 export const SUMMARY_SYSTEM_PROMPT =
   'You are given a transcript of a voice message. Extract a short title, a concise summary, and any concrete action items (tasks, to-dos, follow-ups) mentioned. Each action item must be a short imperative phrase. If there are no clear tasks, return an empty array. Respond ONLY with JSON in this exact shape: {"title": "string", "summary": "string", "actionItems": ["string"]}'
+
+// Builds the full-text search blob for a note from its text fields. Kept in
+// one place so every write path (transcript, summary, manual edit) produces a
+// consistent index value.
+export function buildSearchBlob(fields: {
+  title?: string
+  summary?: string
+  transcription?: string
+}): string {
+  return [fields.title, fields.summary, fields.transcription]
+    .filter((part): part is string => Boolean(part && part.trim().length > 0))
+    .join('\n')
+}
+
+// "Ask your notes" — chat over transcripts.
+// How many notes to retrieve as context for an all-notes question.
+export const ASK_RETRIEVAL_LIMIT = 6
+// Cap per-transcript characters stuffed into the prompt, to bound token use.
+export const ASK_TRANSCRIPT_CHAR_LIMIT = 6000
+
+export const ASK_SYSTEM_PROMPT =
+  'You are a helpful assistant answering questions about the user\'s own voice notes. Answer ONLY using the provided note context. If the answer is not in the context, say you could not find it in their notes. Be concise. When you use a specific note, mention its title.'

--- a/convex/internalMutations.ts
+++ b/convex/internalMutations.ts
@@ -1,6 +1,6 @@
 import { v } from 'convex/values'
 import { internal } from './_generated/api'
-import { NOTE_STATUS } from './constants'
+import { NOTE_STATUS, buildSearchBlob } from './constants'
 import { internalMutation } from './_generated/server'
 
 export const saveTranscript = internalMutation({
@@ -11,8 +11,15 @@ export const saveTranscript = internalMutation({
   handler: async (ctx, args) => {
     const { noteId, transcript } = args
 
+    const note = await ctx.db.get(noteId)
+
     await ctx.db.patch(noteId, {
       transcription: transcript,
+      searchBlob: buildSearchBlob({
+        title: note?.title,
+        summary: note?.summary,
+        transcription: transcript,
+      }),
     })
 
     await ctx.scheduler.runAfter(0, internal.summarize.chat, {
@@ -39,6 +46,11 @@ export const saveSummary = internalMutation({
       summary,
       title,
       status: NOTE_STATUS.READY,
+      searchBlob: buildSearchBlob({
+        title,
+        summary,
+        transcription: note.transcription,
+      }),
     })
 
     // Clear any previously AI-generated items (e.g. on reprocess) so we don't

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -1,6 +1,6 @@
 import { v } from 'convex/values'
 import { internal } from './_generated/api'
-import { NOTE_STATUS } from './constants'
+import { NOTE_STATUS, buildSearchBlob } from './constants'
 import { mutation, query } from './_generated/server'
 
 export const generateUploadUrl = mutation(async (ctx) => {
@@ -214,6 +214,7 @@ export const updateNoteFields = mutation({
       title?: string
       summary?: string
       transcription?: string
+      searchBlob?: string
     } = {}
     if (title !== undefined && title.trim().length > 0) {
       patch.title = title.trim()
@@ -221,7 +222,38 @@ export const updateNoteFields = mutation({
     if (summary !== undefined) patch.summary = summary
     if (transcription !== undefined) patch.transcription = transcription
 
+    // Recompute the search blob from the merged result so edits stay findable.
+    patch.searchBlob = buildSearchBlob({
+      title: patch.title ?? note.title,
+      summary: patch.summary ?? note.summary,
+      transcription: patch.transcription ?? note.transcription,
+    })
+
     await ctx.db.patch(id, patch)
+  },
+})
+
+// Full-text search across the user's own notes (title + summary + transcript)
+// via the search_blob index. Returns the most relevant notes.
+export const searchNotes = query({
+  args: {
+    query: v.string(),
+  },
+  handler: async (ctx, { query: searchQuery }) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity) {
+      throw new Error('Not authenticated')
+    }
+    const userId = identity.subject
+    const trimmed = searchQuery.trim()
+    if (trimmed.length === 0) return []
+
+    return await ctx.db
+      .query('notes')
+      .withSearchIndex('search_blob', (q) =>
+        q.search('searchBlob', trimmed).eq('userId', userId)
+      )
+      .take(20)
   },
 })
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -21,9 +21,17 @@ export default defineSchema({
     // Opaque, unguessable token for the public /share route. Absent until the
     // owner generates a share link. Existing rows have no shareId.
     shareId: v.optional(v.string()),
+    // Concatenated title + summary + transcription, kept in sync on every
+    // write, powering full-text search. Optional: old rows are absent until
+    // re-processed/edited or backfilled.
+    searchBlob: v.optional(v.string()),
   })
     .index('by_userId', ['userId'])
-    .index('by_shareId', ['shareId']),
+    .index('by_shareId', ['shareId'])
+    .searchIndex('search_blob', {
+      searchField: 'searchBlob',
+      filterFields: ['userId'],
+    }),
   actionItems: defineTable({
     noteId: v.id('notes'),
     userId: v.string(),
@@ -34,4 +42,21 @@ export default defineSchema({
   })
     .index('by_noteId', ['noteId'])
     .index('by_userId', ['userId']),
+  // A conversation thread for "Ask your notes". noteId set = scoped to one
+  // note; noteId absent = the user's single all-notes thread.
+  chatThreads: defineTable({
+    userId: v.string(),
+    noteId: v.optional(v.id('notes')),
+    title: v.optional(v.string()),
+  })
+    .index('by_userId', ['userId'])
+    .index('by_noteId', ['noteId']),
+  chatMessages: defineTable({
+    threadId: v.id('chatThreads'),
+    userId: v.string(),
+    role: v.union(v.literal('user'), v.literal('assistant')),
+    content: v.string(),
+    // Notes the assistant drew on (all-notes answers); links back to them.
+    citedNoteIds: v.optional(v.array(v.id('notes'))),
+  }).index('by_threadId', ['threadId']),
 })


### PR DESCRIPTION
## P2 — Search & Ask

Builds on #6 (P1). One retrieval foundation, two features. **No embeddings / no new paid provider** — uses Convex's built-in full-text search.

### 🔎 Foundation
- `notes.searchBlob` = title + summary + transcription, kept in sync on **every** write path (`saveTranscript`, `saveSummary`, `updateNoteFields`) via a shared `buildSearchBlob` helper, indexed by a `search_blob` search index filtered on `userId`.
- `backfill:backfillSearchBlob` internal mutation for pre-existing notes — **already run against the deployment** (13 notes backfilled).

### 🔍 Cross-note search
- `notes.searchNotes` query over the index.
- New `/search` page: debounced input, result cards (title, summary snippet, status) linking to each recording.

### 💬 Ask your notes
- New `chatThreads` + `chatMessages` tables. A **note-scoped** thread, or the user's single **all-notes** thread.
- `chat.ts` (non-node): `getOrCreateThread`, `listMessages`, `ask` (records the user message, schedules the reply), + internal `getThreadContext` (full-text retrieval for all-notes; the single transcript for note-scoped) and `saveAnswer`.
- `chatAnswer.ts` (`'use node'`): Groq-backed answer grounded **only** in retrieved transcripts; all-notes answers carry `citedNoteIds`.
- Reusable `ChatPanel`: an **Ask** tab on the recording detail page + a new **/ask** page with source links. Both added to nav.

### Notes
- All new schema is additive/optional; `convex codegen` validated against the live deployment.
- The retrieval is intentionally keyword-based (RAG-lite). Swapping in vectors later is a one-function change in `getThreadContext`.
- ✅ `tsc --noEmit` and `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)