### PR TITLE
P3: Capture modes — diarization, multi-language, templates, file upload

### DIFF
--- a/app/(dashboard)/record/page.tsx
+++ b/app/(dashboard)/record/page.tsx
@@ -3,11 +3,24 @@
 import { toast } from 'sonner'
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Loader2, Mic, Square } from 'lucide-react'
+import { Loader2, Mic, Square, Upload } from 'lucide-react'
 import { formatTime, getCurrentFormattedDate } from '@/lib/utils'
 
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
+import {
+  NOTE_TEMPLATES,
+  TEMPLATE_OPTIONS,
+  type NoteTemplate,
+} from '@/convex/constants'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 
 type RecordState = 'idle' | 'recording' | 'uploading'
 
@@ -21,7 +34,9 @@ export default function RecordPage() {
   const router = useRouter()
   const [state, setState] = useState<RecordState>('idle')
   const [totalSeconds, setTotalSeconds] = useState(0)
+  const [template, setTemplate] = useState<NoteTemplate>('default')
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   const generateUploadUrl = useMutation(api.notes.generateUploadUrl)
   const createNote = useMutation(api.notes.createNote)
@@ -59,7 +74,7 @@ export default function RecordPage() {
             throw new Error('Upload failed. Please try again.')
           }
           const { storageId } = await result.json()
-          const noteId = await createNote({ storageId })
+          const noteId = await createNote({ storageId, template })
           router.push(`/recordings/${noteId}`)
         } catch (error) {
           setState('idle')
@@ -87,6 +102,37 @@ export default function RecordPage() {
     mediaRecorderRef.current?.stop()
   }
 
+  // Upload an existing audio or video file instead of recording live. Reuses
+  // the same storage-upload → createNote path as a recording.
+  async function handleFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    e.target.value = '' // allow re-selecting the same file later
+    if (!file) return
+
+    setState('uploading')
+    try {
+      const postUrl = await generateUploadUrl()
+      const result = await fetch(postUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': file.type || 'application/octet-stream' },
+        body: file,
+      })
+      if (!result.ok) {
+        throw new Error('Upload failed. Please try again.')
+      }
+      const { storageId } = await result.json()
+      const noteId = await createNote({ storageId, template })
+      router.push(`/recordings/${noteId}`)
+    } catch (error) {
+      setState('idle')
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Something went wrong uploading your file.'
+      )
+    }
+  }
+
   const handleClick = () => {
     if (state === 'idle') void startRecording()
     else if (state === 'recording') stopRecording()
@@ -100,6 +146,32 @@ export default function RecordPage() {
       <p className="mt-2 font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">
         {getCurrentFormattedDate()}
       </p>
+
+      {state === 'idle' && (
+        <div className="mt-8 w-full max-w-xs space-y-1.5">
+          <label className="font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">
+            Summary style
+          </label>
+          <Select
+            value={template}
+            onValueChange={(v) => setTemplate(v as NoteTemplate)}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {NOTE_TEMPLATES.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {TEMPLATE_OPTIONS[t].label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {TEMPLATE_OPTIONS[template].description}
+          </p>
+        </div>
+      )}
 
       <div className="py-16">
         <div className="relative mx-auto flex h-[280px] w-[280px] items-center justify-center sm:h-[316px] sm:w-[316px]">
@@ -135,6 +207,26 @@ export default function RecordPage() {
         {state === 'recording' && 'Tap again to stop and transcribe'}
         {state === 'uploading' && 'Hang tight, this only takes a moment'}
       </p>
+
+      {state === 'idle' && (
+        <div className="mt-8 flex flex-col items-center gap-2">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="inline-flex items-center gap-2 rounded-full border bg-card px-4 py-2 text-sm font-medium shadow-soft transition-colors hover:border-primary/30 hover:text-primary"
+          >
+            <Upload className="h-4 w-4" />
+            Upload an audio or video file
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="audio/*,video/*"
+            onChange={handleFileUpload}
+            className="hidden"
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/app/(dashboard)/recordings/[recordingId]/_components/template-menu.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/template-menu.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { toast } from 'sonner'
+import { useMutation } from 'convex/react'
+import { Wand2 } from 'lucide-react'
+import { api } from '@/convex/_generated/api'
+import { type Id } from '@/convex/_generated/dataModel'
+import {
+  NOTE_TEMPLATES,
+  TEMPLATE_OPTIONS,
+  type NoteTemplate,
+} from '@/convex/constants'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+// Lets the user re-summarize a note in a different style. Changing the value
+// patches the template and re-runs the pipeline.
+export function TemplateMenu({
+  noteId,
+  current,
+}: {
+  noteId: Id<'notes'>
+  current: NoteTemplate
+}) {
+  const reprocess = useMutation(api.notes.reprocessNote)
+
+  const onChange = (value: string) => {
+    const template = value as NoteTemplate
+    if (template === current) return
+    const promise = reprocess({ id: noteId, template })
+    toast.promise(promise, {
+      loading: `Re-summarizing as ${TEMPLATE_OPTIONS[template].label}…`,
+      success: 'Re-summarizing your note…',
+      error: 'Failed to re-summarize',
+    })
+  }
+
+  return (
+    <Select value={current} onValueChange={onChange}>
+      <SelectTrigger className="h-9 w-[190px] gap-2 text-sm">
+        <Wand2 className="h-4 w-4 text-muted-foreground" />
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align="end">
+        {NOTE_TEMPLATES.map((t) => (
+          <SelectItem key={t} value={t}>
+            {TEMPLATE_OPTIONS[t].label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/app/(dashboard)/recordings/[recordingId]/_components/transcript-view.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/transcript-view.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { type RefObject } from 'react'
+import { cn, formatDuration } from '@/lib/utils'
+
+export interface Utterance {
+  speaker: string
+  text: string
+  start: number // milliseconds
+  end: number // milliseconds
+}
+
+// Stable-ish color per speaker letter so "Speaker A" reads consistently.
+const SPEAKER_COLORS = [
+  'bg-primary/10 text-primary',
+  'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  'bg-violet-500/10 text-violet-600 dark:text-violet-400',
+  'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  'bg-rose-500/10 text-rose-600 dark:text-rose-400',
+]
+
+function speakerColor(speaker: string): string {
+  const code = speaker.charCodeAt(0) || 0
+  return (
+    SPEAKER_COLORS[code % SPEAKER_COLORS.length] ?? 'bg-primary/10 text-primary'
+  )
+}
+
+interface TranscriptViewProps {
+  utterances: Utterance[]
+  // When provided, clicking a line seeks the audio to that moment.
+  audioRef?: RefObject<HTMLAudioElement | null>
+}
+
+export function TranscriptView({ utterances, audioRef }: TranscriptViewProps) {
+  const seekTo = (startMs: number) => {
+    const audio = audioRef?.current
+    if (!audio) return
+    audio.currentTime = startMs / 1000
+    void audio.play()
+  }
+
+  return (
+    <div className="space-y-4">
+      {utterances.map((u, i) => {
+        const clickable = Boolean(audioRef)
+        return (
+          <div
+            key={i}
+            className={cn(
+              'flex gap-3 rounded-lg p-2 -mx-2 transition-colors',
+              clickable && 'cursor-pointer hover:bg-muted/60'
+            )}
+            onClick={clickable ? () => seekTo(u.start) : undefined}
+            role={clickable ? 'button' : undefined}
+            tabIndex={clickable ? 0 : undefined}
+            onKeyDown={
+              clickable
+                ? (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      seekTo(u.start)
+                    }
+                  }
+                : undefined
+            }
+          >
+            <div className="flex w-16 shrink-0 flex-col items-start gap-1">
+              <span
+                className={cn(
+                  'rounded-full px-2 py-0.5 font-mono text-[11px] font-medium uppercase tracking-wide',
+                  speakerColor(u.speaker)
+                )}
+              >
+                {u.speaker}
+              </span>
+              <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+                {formatDuration(u.start / 1000)}
+              </span>
+            </div>
+            <p className="flex-1 text-[15px] leading-relaxed text-foreground/90">
+              {u.text}
+            </p>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/(dashboard)/recordings/[recordingId]/page.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useRef } from 'react'
 import { useQuery } from 'convex/react'
 import { notFound, useParams } from 'next/navigation'
 import { ChevronLeft } from 'lucide-react'
@@ -8,16 +9,19 @@ import { api } from '@/convex/_generated/api'
 import { type Id } from '@/convex/_generated/dataModel'
 
 import NoteTabs from '@/components/note-tabs'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/status-badge'
 import { ActionItemSkeleton } from '@/components/skeletons'
 import ShareNoteModal from '@/components/share-note-modal'
 import { AudioPlayer } from './_components/audio-player'
 import { EditableField } from './_components/editable-field'
+import { TemplateMenu } from './_components/template-menu'
 
 export default function RecordingIdPage() {
   const params = useParams()
   const recordingId = params.recordingId as Id<'notes'>
+  const audioRef = useRef<HTMLAudioElement>(null)
 
   const noteWithActionItems = useQuery(api.notes.getNoteById, {
     id: recordingId,
@@ -63,18 +67,31 @@ export default function RecordingIdPage() {
             placeholder="Untitled note"
             className="text-3xl font-medium tracking-tight sm:text-4xl"
           />
-          <StatusBadge status={status} />
+          <div className="flex flex-wrap items-center gap-2">
+            <StatusBadge status={status} />
+            {note.language && (
+              <Badge variant="outline" className="font-mono uppercase">
+                {note.language}
+              </Badge>
+            )}
+          </div>
         </div>
         <ShareNoteModal noteId={note._id} />
       </div>
 
       {note.audioFileUrl && (
-        <div className="mb-8">
-          <AudioPlayer src={note.audioFileUrl} />
+        <div className="mb-6">
+          <AudioPlayer ref={audioRef} src={note.audioFileUrl} />
         </div>
       )}
 
-      <NoteTabs note={note} actionItems={actionItems} />
+      {status === 'ready' && (
+        <div className="mb-8 flex items-center justify-end">
+          <TemplateMenu noteId={note._id} current={note.template ?? 'default'} />
+        </div>
+      )}
+
+      <NoteTabs note={note} actionItems={actionItems} audioRef={audioRef} />
     </div>
   )
 }

--- a/components/note-tabs.tsx
+++ b/components/note-tabs.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { toast } from 'sonner'
+import { type RefObject } from 'react'
 import { useMutation } from 'convex/react'
 import { Loader2, AlertCircle, ListTodo, RotateCw } from 'lucide-react'
 import { api } from '@/convex/_generated/api'
@@ -14,11 +15,13 @@ import { EmptyState } from '@/components/empty-state'
 import NoteCard from '@/app/(dashboard)/recordings/[recordingId]/_components/note-card'
 import ActionForm from '@/app/(dashboard)/recordings/[recordingId]/_components/action-form'
 import { EditableField } from '@/app/(dashboard)/recordings/[recordingId]/_components/editable-field'
+import { TranscriptView } from '@/app/(dashboard)/recordings/[recordingId]/_components/transcript-view'
 
 interface NoteTabsProps {
   note: Doc<'notes'>
   actionItems: Doc<'actionItems'>[]
   readOnly?: boolean
+  audioRef?: RefObject<HTMLAudioElement | null>
 }
 
 function ProcessingState({ label }: { label: string }) {
@@ -77,6 +80,7 @@ export default function NoteTabs({
   note,
   actionItems,
   readOnly = false,
+  audioRef,
 }: NoteTabsProps) {
   const isProcessing = note.status === 'processing'
   const isFailed = note.status === 'failed'
@@ -88,6 +92,19 @@ export default function NoteTabs({
   ) => {
     if (isFailed) return <FailedState noteId={note._id} readOnly={readOnly} />
     if (isProcessing) return <ProcessingState label={processingLabel} />
+
+    // Diarized transcript: show speaker-labeled, click-to-seek segments.
+    if (
+      field === 'transcription' &&
+      note.utterances &&
+      note.utterances.length > 0
+    ) {
+      return (
+        <div className="rounded-xl border bg-card p-5 shadow-soft sm:p-6">
+          <TranscriptView utterances={note.utterances} audioRef={audioRef} />
+        </div>
+      )
+    }
     return (
       <div className="rounded-xl border bg-card p-5 shadow-soft sm:p-6">
         {readOnly ? (

--- a/convex/assembly.ts
+++ b/convex/assembly.ts
@@ -4,7 +4,6 @@ import { v } from 'convex/values'
 import { AssemblyAI } from 'assemblyai'
 import { internal } from './_generated/api'
 import { requireEnv } from './env'
-import { TRANSCRIPTION_LANGUAGE } from './constants'
 import { internalAction } from './_generated/server'
 
 export const doTranscribe = internalAction({
@@ -18,9 +17,13 @@ export const doTranscribe = internalAction({
     try {
       const client = new AssemblyAI({ apiKey: requireEnv('ASSEMBLY_API_KEY') })
 
+      // Auto-detect the language and label speakers. Both are best-effort:
+      // diarization isn't available for every language, so utterances may come
+      // back empty — we handle that downstream.
       const response = await client.transcripts.transcribe({
         audio_url: fileUrl,
-        language_code: TRANSCRIPTION_LANGUAGE,
+        language_detection: true,
+        speaker_labels: true,
       })
 
       if (response.status === 'error' || !response.text) {
@@ -29,9 +32,18 @@ export const doTranscribe = internalAction({
         )
       }
 
+      const utterances = (response.utterances ?? []).map((u) => ({
+        speaker: u.speaker,
+        text: u.text,
+        start: u.start,
+        end: u.end,
+      }))
+
       await ctx.runMutation(internal.internalMutations.saveTranscript, {
         noteId,
         transcript: response.text,
+        utterances: utterances.length > 0 ? utterances : undefined,
+        language: response.language_code ?? undefined,
       })
     } catch (error) {
       console.error('Transcription failed:', error)

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -7,6 +7,7 @@ export const NOTE_STATUS = {
 export type NoteStatus = (typeof NOTE_STATUS)[keyof typeof NOTE_STATUS]
 
 // AssemblyAI
+// Fallback language when detection is unavailable. The pipeline auto-detects.
 export const TRANSCRIPTION_LANGUAGE = 'en'
 
 // Groq
@@ -15,8 +16,55 @@ export const SUMMARY_MODEL = 'llama-3.3-70b-versatile'
 // Cap on how many action items the model may return, to bound output size.
 export const MAX_ACTION_ITEMS = 10
 
-export const SUMMARY_SYSTEM_PROMPT =
-  'You are given a transcript of a voice message. Extract a short title, a concise summary, and any concrete action items (tasks, to-dos, follow-ups) mentioned. Each action item must be a short imperative phrase. If there are no clear tasks, return an empty array. Respond ONLY with JSON in this exact shape: {"title": "string", "summary": "string", "actionItems": ["string"]}'
+// Every prompt must return the same JSON shape so the parser is uniform.
+const JSON_CONTRACT =
+  'Respond ONLY with JSON in this exact shape: {"title": "string", "summary": "string", "actionItems": ["string"]}. Each action item is a short imperative phrase; use an empty array if there are none.'
+
+export const SUMMARY_SYSTEM_PROMPT = `You are given a transcript of a voice message. Extract a short title, a concise summary, and any concrete action items (tasks, to-dos, follow-ups) mentioned. ${JSON_CONTRACT}`
+
+// Summary styles the user can pick. Each reshapes the summary framing but keeps
+// the same JSON contract (title + summary + actionItems).
+export const NOTE_TEMPLATES = [
+  'default',
+  'meeting',
+  'lecture',
+  'journal',
+  'email',
+  'blog',
+] as const
+
+export type NoteTemplate = (typeof NOTE_TEMPLATES)[number]
+
+// User-facing labels + descriptions for the template picker.
+export const TEMPLATE_OPTIONS: Record<
+  NoteTemplate,
+  { label: string; description: string }
+> = {
+  default: { label: 'General note', description: 'A clean, neutral summary.' },
+  meeting: {
+    label: 'Meeting notes',
+    description: 'Decisions, discussion points, and next steps.',
+  },
+  lecture: {
+    label: 'Lecture notes',
+    description: 'Key concepts and takeaways, study-friendly.',
+  },
+  journal: {
+    label: 'Journal entry',
+    description: 'A reflective, first-person recap.',
+  },
+  email: { label: 'Email draft', description: 'A ready-to-send email body.' },
+  blog: { label: 'Blog outline', description: 'A structured post outline.' },
+}
+
+export const SUMMARY_PROMPTS: Record<NoteTemplate, string> = {
+  default: SUMMARY_SYSTEM_PROMPT,
+  meeting: `You are given a transcript of a meeting. Produce a short title; a summary written as meeting notes covering decisions made, key discussion points, and agreed next steps; and the concrete action items. ${JSON_CONTRACT}`,
+  lecture: `You are given a transcript of a lecture or talk. Produce a short title; a study-friendly summary of the key concepts, definitions, and takeaways; and any action items such as readings or assignments. ${JSON_CONTRACT}`,
+  journal: `You are given a transcript of a spoken journal entry. Produce a short title; a reflective first-person recap that preserves the speaker's voice; and any action items they mentioned. ${JSON_CONTRACT}`,
+  email: `You are given a transcript dictating an email. Produce a short title (the subject line); a summary field containing a polished, ready-to-send email body; and any action items implied. ${JSON_CONTRACT}`,
+  blog: `You are given a transcript of spoken ideas for a blog post. Produce a short title; a summary field containing a structured post outline with headings and bullet points; and any action items such as research to do. ${JSON_CONTRACT}`,
+}
 
 // Builds the full-text search blob for a note from its text fields. Kept in
 // one place so every write path (transcript, summary, manual edit) produces a

--- a/convex/internalMutations.ts
+++ b/convex/internalMutations.ts
@@ -1,20 +1,33 @@
 import { v } from 'convex/values'
 import { internal } from './_generated/api'
 import { NOTE_STATUS, buildSearchBlob } from './constants'
-import { internalMutation } from './_generated/server'
+import { internalMutation, internalQuery } from './_generated/server'
 
 export const saveTranscript = internalMutation({
   args: {
     noteId: v.id('notes'),
     transcript: v.string(),
+    utterances: v.optional(
+      v.array(
+        v.object({
+          speaker: v.string(),
+          text: v.string(),
+          start: v.number(),
+          end: v.number(),
+        })
+      )
+    ),
+    language: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const { noteId, transcript } = args
+    const { noteId, transcript, utterances, language } = args
 
     const note = await ctx.db.get(noteId)
 
     await ctx.db.patch(noteId, {
       transcription: transcript,
+      utterances,
+      language,
       searchBlob: buildSearchBlob({
         title: note?.title,
         summary: note?.summary,
@@ -26,6 +39,19 @@ export const saveTranscript = internalMutation({
       noteId,
       transcript,
     })
+  },
+})
+
+// Read-only helper for the summarization action (a Node action can't touch the
+// db directly) to learn which template/language a note should be summarized as.
+export const getNoteMeta = internalQuery({
+  args: {
+    noteId: v.id('notes'),
+  },
+  handler: async (ctx, { noteId }) => {
+    const note = await ctx.db.get(noteId)
+    if (!note) return null
+    return { template: note.template, language: note.language }
   },
 })
 

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -7,11 +7,21 @@ export const generateUploadUrl = mutation(async (ctx) => {
   return await ctx.storage.generateUploadUrl()
 })
 
+const templateValidator = v.union(
+  v.literal('default'),
+  v.literal('meeting'),
+  v.literal('lecture'),
+  v.literal('journal'),
+  v.literal('email'),
+  v.literal('blog')
+)
+
 export const createNote = mutation({
   args: {
     storageId: v.id('_storage'),
+    template: v.optional(templateValidator),
   },
-  handler: async (ctx, { storageId }) => {
+  handler: async (ctx, { storageId, template }) => {
     const identity = await ctx.auth.getUserIdentity()
     if (!identity) {
       throw new Error('Not authenticated')
@@ -29,6 +39,7 @@ export const createNote = mutation({
       audioFileId: storageId,
       audioFileUrl: fileUrl,
       status: NOTE_STATUS.PROCESSING,
+      template,
     })
 
     await ctx.scheduler.runAfter(0, internal.assembly.doTranscribe, {
@@ -149,8 +160,10 @@ export const createShareLink = mutation({
 export const reprocessNote = mutation({
   args: {
     id: v.id('notes'),
+    // Optionally re-summarize with a different template.
+    template: v.optional(templateValidator),
   },
-  handler: async (ctx, { id }) => {
+  handler: async (ctx, { id, template }) => {
     const identity = await ctx.auth.getUserIdentity()
     if (!identity) {
       throw new Error('Not authenticated')
@@ -177,7 +190,10 @@ export const reprocessNote = mutation({
         .map((item) => ctx.db.delete(item._id))
     )
 
-    await ctx.db.patch(id, { status: NOTE_STATUS.PROCESSING })
+    await ctx.db.patch(id, {
+      status: NOTE_STATUS.PROCESSING,
+      ...(template ? { template } : {}),
+    })
 
     await ctx.scheduler.runAfter(0, internal.assembly.doTranscribe, {
       fileUrl: note.audioFileUrl,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -25,6 +25,31 @@ export default defineSchema({
     // write, powering full-text search. Optional: old rows are absent until
     // re-processed/edited or backfilled.
     searchBlob: v.optional(v.string()),
+    // Speaker-diarized segments (one per speaker turn). start/end are in
+    // milliseconds. Absent when diarization wasn't available for the audio.
+    utterances: v.optional(
+      v.array(
+        v.object({
+          speaker: v.string(),
+          text: v.string(),
+          start: v.number(),
+          end: v.number(),
+        })
+      )
+    ),
+    // Detected spoken-language code (e.g. 'en', 'es'). Absent on old notes.
+    language: v.optional(v.string()),
+    // The summary style chosen for this note. Absent = 'default'.
+    template: v.optional(
+      v.union(
+        v.literal('default'),
+        v.literal('meeting'),
+        v.literal('lecture'),
+        v.literal('journal'),
+        v.literal('email'),
+        v.literal('blog')
+      )
+    ),
   })
     .index('by_userId', ['userId'])
     .index('by_shareId', ['shareId'])

--- a/convex/summarize.ts
+++ b/convex/summarize.ts
@@ -7,7 +7,7 @@ import { requireEnv } from './env'
 import {
   MAX_ACTION_ITEMS,
   SUMMARY_MODEL,
-  SUMMARY_SYSTEM_PROMPT,
+  SUMMARY_PROMPTS,
 } from './constants'
 import { internalAction } from './_generated/server'
 
@@ -37,13 +37,23 @@ export const chat = internalAction({
     const { noteId, transcript } = args
 
     try {
+      const meta = await ctx.runQuery(
+        internal.internalMutations.getNoteMeta,
+        { noteId }
+      )
+      const template = meta?.template ?? 'default'
+      const systemPrompt = SUMMARY_PROMPTS[template] ?? SUMMARY_PROMPTS.default
+      const languageDirective = meta?.language
+        ? ` Write the title and summary in the same language as the transcript (detected: ${meta.language}).`
+        : ''
+
       const groq = new Groq({ apiKey: requireEnv('GROQ_API_KEY') })
 
       const completion = await groq.chat.completions.create({
         model: SUMMARY_MODEL,
         response_format: { type: 'json_object' },
         messages: [
-          { role: 'system', content: SUMMARY_SYSTEM_PROMPT },
+          { role: 'system', content: systemPrompt + languageDirective },
           { role: 'user', content: `Here is the transcript:\n${transcript}` },
         ],
       })


### PR DESCRIPTION
## P3 — Capture modes

Builds on #7 (P2). Clusters all the transcribe/summarize call-shape changes into one phase so those files are touched once.

### 🎙️ Speaker diarization + click-to-seek
- `assembly.ts` now requests `speaker_labels` and stores diarized **utterances** (speaker + text + start/end in ms) on the note.
- New `TranscriptView` renders speaker-labeled segments; **clicking a segment seeks the audio**. The player ref is lifted in the detail page and threaded through `NoteTabs`. The read-only `/share` view shows speakers but no seek.

### 🌍 Multi-language
- Dropped the hardcoded `language_code` in favor of `language_detection`. The detected code is stored and shown as a badge, and the summarizer is told to write in the transcript's language.

### 📋 Output templates
- A note carries a `template` (default / meeting / lecture / journal / email / blog). `summarize.ts` selects the matching prompt (all share the same JSON contract) via a new `getNoteMeta` internal query.
- Pickable on the **record page**, re-pickable on the **detail page** (reprocess-with-template menu).

### 📁 File / video upload
- The record page can upload an existing **audio or video** file, reusing the same `generateUploadUrl → createNote` path.

### ⚠️ Risk note
Enabling `speaker_labels` + `language_detection` together is the call-shape change flagged in the plan. English audio is unaffected; for some languages diarization may not apply, so `utterances` can come back empty — all transcript fields are read **defensively** and existing notes are untouched. Worth a quick smoke test on a real multi-speaker recording.

✅ `tsc --noEmit` and `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)