### PR TITLE
P4: Organize & export — tags + Markdown/print-PDF

### DIFF
--- a/app/(dashboard)/recordings/[recordingId]/_components/export-menu.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/export-menu.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { Download, FileDown, Printer } from 'lucide-react'
+import { type Doc } from '@/convex/_generated/dataModel'
+
+import { downloadNoteMarkdown } from '@/lib/export'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+// Export options for a note: download as Markdown, or print / save as PDF via
+// the browser's print dialog (a print stylesheet renders a clean page).
+export function ExportMenu({
+  note,
+  actionItems,
+}: {
+  note: Doc<'notes'>
+  actionItems: Doc<'actionItems'>[]
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="h-8 gap-2">
+          <Download className="h-4 w-4" />
+          Export
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuItem onClick={() => downloadNoteMarkdown(note, actionItems)}>
+          <FileDown className="mr-2 h-4 w-4" />
+          Download Markdown
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => window.print()}>
+          <Printer className="mr-2 h-4 w-4" />
+          Print / Save as PDF
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/app/(dashboard)/recordings/[recordingId]/_components/note-organize.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/note-organize.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { toast } from 'sonner'
+import { useState, type KeyboardEvent } from 'react'
+import { useMutation } from 'convex/react'
+import { Tag, X } from 'lucide-react'
+import { api } from '@/convex/_generated/api'
+import { type Doc, type Id } from '@/convex/_generated/dataModel'
+
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+
+// Tag controls for the recording detail page. Edits persist immediately via
+// Convex. (Folders are intentionally deferred to a future sidebar-style UI.)
+export function NoteOrganize({ note }: { note: Doc<'notes'> }) {
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-soft sm:p-5">
+      <TagEditor noteId={note._id} tags={note.tags ?? []} />
+    </div>
+  )
+}
+
+function TagEditor({ noteId, tags }: { noteId: Id<'notes'>; tags: string[] }) {
+  const updateTags = useMutation(api.organize.updateNoteTags)
+  const [draft, setDraft] = useState('')
+
+  const commit = (next: string[]) => {
+    const promise = updateTags({ id: noteId, tags: next })
+    promise.catch(() => toast.error('Failed to update tags'))
+  }
+
+  const addTag = () => {
+    const value = draft.trim()
+    if (value.length === 0) return
+    if (tags.some((t) => t.toLowerCase() === value.toLowerCase())) {
+      setDraft('')
+      return
+    }
+    commit([...tags, value])
+    setDraft('')
+  }
+
+  const removeTag = (tag: string) => {
+    commit(tags.filter((t) => t !== tag))
+  }
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault()
+      addTag()
+    } else if (e.key === 'Backspace' && draft.length === 0) {
+      const last = tags[tags.length - 1]
+      if (last) removeTag(last)
+    }
+  }
+
+  return (
+    <div className="min-w-0 space-y-2">
+      <p className="flex items-center gap-1.5 font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+        <Tag className="h-3.5 w-3.5" />
+        Tags
+      </p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {tags.map((tag) => (
+          <Badge key={tag} variant="secondary" className="gap-1 pr-1">
+            {tag}
+            <button
+              type="button"
+              onClick={() => removeTag(tag)}
+              className="rounded-full p-0.5 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+              aria-label={`Remove ${tag}`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        ))}
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKeyDown}
+          onBlur={addTag}
+          placeholder={tags.length === 0 ? 'Add a tag…' : 'Add…'}
+          className="h-7 w-28 border-dashed bg-transparent px-2 text-sm shadow-none focus-visible:ring-1"
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/(dashboard)/recordings/[recordingId]/_components/printable-note.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/printable-note.tsx
@@ -1,0 +1,69 @@
+import { type Doc } from '@/convex/_generated/dataModel'
+import { formatDate } from '@/lib/utils'
+
+// A clean, single-page rendering of a note used only when printing (or saving
+// as PDF). Hidden on screen; the interactive page is hidden in print. This
+// avoids fighting the tabbed UI, which only mounts one panel at a time.
+export function PrintableNote({
+  note,
+  actionItems,
+}: {
+  note: Doc<'notes'>
+  actionItems: Doc<'actionItems'>[]
+}) {
+  const meta = [formatDate(note._creationTime)]
+  if (note.language) meta.push(`Language: ${note.language}`)
+
+  return (
+    <article className="hidden text-black print:block">
+      <header className="mb-6 border-b border-black/20 pb-4">
+        <h1 className="text-2xl font-semibold">
+          {note.title ?? 'Untitled note'}
+        </h1>
+        <p className="mt-1 text-sm text-black/60">{meta.join(' · ')}</p>
+        {note.tags && note.tags.length > 0 && (
+          <p className="mt-1 text-sm text-black/60">
+            {note.tags.map((t) => `#${t}`).join('  ')}
+          </p>
+        )}
+      </header>
+
+      {note.summary && note.summary.trim().length > 0 && (
+        <section className="mb-6">
+          <h2 className="mb-2 text-lg font-semibold">Summary</h2>
+          <div className="whitespace-pre-wrap text-[15px] leading-relaxed">
+            {note.summary}
+          </div>
+        </section>
+      )}
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-lg font-semibold">Transcript</h2>
+        {note.utterances && note.utterances.length > 0 ? (
+          <div className="space-y-2 text-[15px] leading-relaxed">
+            {note.utterances.map((u, i) => (
+              <p key={i}>
+                <span className="font-semibold">{u.speaker}:</span> {u.text}
+              </p>
+            ))}
+          </div>
+        ) : (
+          <div className="whitespace-pre-wrap text-[15px] leading-relaxed">
+            {note.transcription ?? '—'}
+          </div>
+        )}
+      </section>
+
+      {actionItems.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-lg font-semibold">Action items</h2>
+          <ul className="list-inside list-disc space-y-1 text-[15px]">
+            {actionItems.map((item) => (
+              <li key={item._id}>{item.action}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </article>
+  )
+}

--- a/app/(dashboard)/recordings/[recordingId]/page.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/page.tsx
@@ -17,6 +17,9 @@ import ShareNoteModal from '@/components/share-note-modal'
 import { AudioPlayer } from './_components/audio-player'
 import { EditableField } from './_components/editable-field'
 import { TemplateMenu } from './_components/template-menu'
+import { ExportMenu } from './_components/export-menu'
+import { NoteOrganize } from './_components/note-organize'
+import { PrintableNote } from './_components/printable-note'
 
 export default function RecordingIdPage() {
   const params = useParams()
@@ -49,49 +52,61 @@ export default function RecordingIdPage() {
   const status = note.status ?? 'ready'
 
   return (
-    <div className="mx-auto w-full max-w-2xl px-4 py-8 sm:px-6">
-      <Button asChild variant="ghost" size="sm" className="mb-4 -ml-2">
-        <Link href="/recordings">
-          <ChevronLeft className="mr-1 h-4 w-4" />
-          Back to recordings
-        </Link>
-      </Button>
+    <>
+      <div className="mx-auto w-full max-w-2xl px-4 py-8 print:hidden sm:px-6">
+        <Button asChild variant="ghost" size="sm" className="mb-4 -ml-2">
+          <Link href="/recordings">
+            <ChevronLeft className="mr-1 h-4 w-4" />
+            Back to recordings
+          </Link>
+        </Button>
 
-      <div className="mb-6 flex items-start justify-between gap-4">
-        <div className="min-w-0 flex-1 space-y-3">
-          <p className="eyebrow">Recording</p>
-          <EditableField
-            noteId={note._id}
-            field="title"
-            value={note.title ?? ''}
-            placeholder="Untitled note"
-            className="text-3xl font-medium tracking-tight sm:text-4xl"
-          />
-          <div className="flex flex-wrap items-center gap-2">
-            <StatusBadge status={status} />
-            {note.language && (
-              <Badge variant="outline" className="font-mono uppercase">
-                {note.language}
-              </Badge>
-            )}
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1 space-y-3">
+            <p className="eyebrow">Recording</p>
+            <EditableField
+              noteId={note._id}
+              field="title"
+              value={note.title ?? ''}
+              placeholder="Untitled note"
+              className="text-3xl font-medium tracking-tight sm:text-4xl"
+            />
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusBadge status={status} />
+              {note.language && (
+                <Badge variant="outline" className="font-mono uppercase">
+                  {note.language}
+                </Badge>
+              )}
+            </div>
           </div>
+          <ShareNoteModal noteId={note._id} />
         </div>
-        <ShareNoteModal noteId={note._id} />
+
+        {note.audioFileUrl && (
+          <div className="mb-6">
+            <AudioPlayer ref={audioRef} src={note.audioFileUrl} />
+          </div>
+        )}
+
+        <div className="mb-6">
+          <NoteOrganize note={note} />
+        </div>
+
+        <div className="mb-8 flex items-center justify-end gap-2">
+          <ExportMenu note={note} actionItems={actionItems} />
+          {status === 'ready' && (
+            <TemplateMenu
+              noteId={note._id}
+              current={note.template ?? 'default'}
+            />
+          )}
+        </div>
+
+        <NoteTabs note={note} actionItems={actionItems} audioRef={audioRef} />
       </div>
 
-      {note.audioFileUrl && (
-        <div className="mb-6">
-          <AudioPlayer ref={audioRef} src={note.audioFileUrl} />
-        </div>
-      )}
-
-      {status === 'ready' && (
-        <div className="mb-8 flex items-center justify-end">
-          <TemplateMenu noteId={note._id} current={note.template ?? 'default'} />
-        </div>
-      )}
-
-      <NoteTabs note={note} actionItems={actionItems} audioRef={audioRef} />
-    </div>
+      <PrintableNote note={note} actionItems={actionItems} />
+    </>
   )
 }

--- a/app/(dashboard)/recordings/_components/columns.tsx
+++ b/app/(dashboard)/recordings/_components/columns.tsx
@@ -2,13 +2,14 @@
 
 import { ArrowUpDown } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { type Column, type ColumnDef } from '@tanstack/react-table'
 import { type Id } from '@/convex/_generated/dataModel'
 import { StatusBadge, type NoteStatus } from '@/components/status-badge'
 import { DataTableRowActions } from './data-table-row-actions'
 
-interface Note {
+export interface NoteRow {
   _creationTime: number
   _id: Id<'notes'>
   audioFileId: string
@@ -18,13 +19,14 @@ interface Note {
   transcription?: string
   status?: NoteStatus
   userId: string
+  tags?: string[]
 }
 
 function SortableHeader({
   column,
   title,
 }: {
-  column: Column<Note, unknown>
+  column: Column<NoteRow, unknown>
   title: string
 }) {
   return (
@@ -39,7 +41,15 @@ function SortableHeader({
   )
 }
 
-export const columns: ColumnDef<Note>[] = [
+function HeaderLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="font-mono text-xs font-medium uppercase tracking-[0.15em] text-muted-foreground">
+      {children}
+    </span>
+  )
+}
+
+export const columns: ColumnDef<NoteRow>[] = [
   {
     accessorKey: 'title',
     header: ({ column }) => <SortableHeader column={column} title="Title" />,
@@ -53,12 +63,42 @@ export const columns: ColumnDef<Note>[] = [
     },
   },
   {
+    accessorKey: 'tags',
+    header: () => <HeaderLabel>Tags</HeaderLabel>,
+    enableSorting: false,
+    // Matches if the row carries any of the selected tags (OR semantics).
+    filterFn: (row, id, value: string[]) => {
+      if (!value || value.length === 0) return true
+      const tags = row.getValue<string[] | undefined>(id) ?? []
+      return value.some((v) => tags.includes(v))
+    },
+    cell: ({ row }) => {
+      const tags = row.original.tags ?? []
+      if (tags.length === 0)
+        return <span className="text-muted-foreground">—</span>
+      return (
+        <div className="flex max-w-[260px] flex-wrap gap-1">
+          {tags.slice(0, 3).map((tag) => (
+            <Badge
+              key={tag}
+              variant="secondary"
+              className="font-mono text-[10px] uppercase tracking-[0.08em]"
+            >
+              {tag}
+            </Badge>
+          ))}
+          {tags.length > 3 && (
+            <span className="text-xs text-muted-foreground">
+              +{tags.length - 3}
+            </span>
+          )}
+        </div>
+      )
+    },
+  },
+  {
     accessorKey: 'status',
-    header: () => (
-      <span className="font-mono text-xs font-medium uppercase tracking-[0.15em] text-muted-foreground">
-        Status
-      </span>
-    ),
+    header: () => <HeaderLabel>Status</HeaderLabel>,
     cell: ({ row }) => {
       const status = row.original.status ?? 'ready'
       return <StatusBadge status={status} />

--- a/app/(dashboard)/recordings/_components/data-table.tsx
+++ b/app/(dashboard)/recordings/_components/data-table.tsx
@@ -21,13 +21,28 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { Search } from 'lucide-react'
+import { ChevronDown, Search, Tag, X } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
   data: TData[]
+}
+
+// Minimal shape the filter toolbar reads off each row. `data` is generic, so we
+// narrow to this when deriving tag options.
+interface FilterableRow {
+  tags?: string[]
 }
 
 export function DataTable<TData, TValue>({
@@ -51,18 +66,79 @@ export function DataTable<TData, TValue>({
     getPaginationRowModel: getPaginationRowModel(),
   })
 
+  // Distinct tags across the data, for the filter dropdown.
+  const allTags = React.useMemo(() => {
+    const tagSet = new Set<string>()
+    for (const row of data as FilterableRow[]) {
+      for (const tag of row.tags ?? []) tagSet.add(tag)
+    }
+    return [...tagSet].sort((a, b) => a.localeCompare(b))
+  }, [data])
+
+  const tagColumn = table.getColumn('tags')
+  const selectedTags = (tagColumn?.getFilterValue() as string[]) ?? []
+
+  const toggleTag = (tag: string) => {
+    const next = selectedTags.includes(tag)
+      ? selectedTags.filter((t) => t !== tag)
+      : [...selectedTags, tag]
+    tagColumn?.setFilterValue(next.length > 0 ? next : undefined)
+  }
+
   return (
     <div className="space-y-4">
-      <div className="relative max-w-sm">
-        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          placeholder="Search notes…"
-          value={(table.getColumn('title')?.getFilterValue() as string) ?? ''}
-          onChange={(event) =>
-            table.getColumn('title')?.setFilterValue(event.target.value)
-          }
-          className="pl-9"
-        />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative max-w-sm flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search notes…"
+            value={(table.getColumn('title')?.getFilterValue() as string) ?? ''}
+            onChange={(event) =>
+              table.getColumn('title')?.setFilterValue(event.target.value)
+            }
+            className="pl-9"
+          />
+        </div>
+
+        {allTags.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="gap-2">
+                <Tag className="h-4 w-4 text-muted-foreground" />
+                Tags
+                {selectedTags.length > 0 && (
+                  <span className="rounded-full bg-primary px-1.5 text-xs text-primary-foreground">
+                    {selectedTags.length}
+                  </span>
+                )}
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-52">
+              <DropdownMenuLabel>Filter by tag</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {allTags.map((tag) => (
+                <DropdownMenuCheckboxItem
+                  key={tag}
+                  checked={selectedTags.includes(tag)}
+                  onCheckedChange={() => toggleTag(tag)}
+                  onSelect={(e) => e.preventDefault()}
+                >
+                  {tag}
+                </DropdownMenuCheckboxItem>
+              ))}
+              {selectedTags.length > 0 && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => tagColumn?.setFilterValue(undefined)}>
+                    <X className="mr-2 h-4 w-4" />
+                    Clear tags
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
 
       <div className="overflow-hidden rounded-xl border bg-card shadow-soft">

--- a/app/(dashboard)/recordings/_components/notes-wrapper.tsx
+++ b/app/(dashboard)/recordings/_components/notes-wrapper.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { columns } from './columns'
+import { columns, type NoteRow } from './columns'
 import { DataTable } from './data-table'
 import { Mic } from 'lucide-react'
 import { type api } from '@/convex/_generated/api'
@@ -14,6 +14,7 @@ export function NotesWrapper(props: {
   preloadedNotes: Preloaded<typeof api.notes.getUserNotes>
 }) {
   const userNotes = usePreloadedQuery(props.preloadedNotes)
+  const data: NoteRow[] = userNotes
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
@@ -47,7 +48,7 @@ export function NotesWrapper(props: {
           className="mt-6"
         />
       ) : (
-        <DataTable data={userNotes} columns={columns} />
+        <DataTable data={data} columns={columns} />
       )}
     </div>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -194,3 +194,18 @@
     );
   }
 }
+
+/* Print: show only the clean PrintableNote, hide app chrome. The detail
+   page wraps its interactive UI in .print:hidden; nav/footer/toasts are hidden
+   here so "Save as PDF" produces a clean, single document. */
+@media print {
+  nav,
+  footer,
+  [data-sonner-toaster] {
+    display: none !important;
+  }
+
+  body {
+    background: #fff !important;
+  }
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as constants from "../constants.js";
 import type * as env from "../env.js";
 import type * as internalMutations from "../internalMutations.js";
 import type * as notes from "../notes.js";
+import type * as organize from "../organize.js";
 import type * as summarize from "../summarize.js";
 
 import type {
@@ -33,6 +34,7 @@ declare const fullApi: ApiFromModules<{
   env: typeof env;
   internalMutations: typeof internalMutations;
   notes: typeof notes;
+  organize: typeof organize;
   summarize: typeof summarize;
 }>;
 

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -67,14 +67,20 @@ export const SUMMARY_PROMPTS: Record<NoteTemplate, string> = {
 }
 
 // Builds the full-text search blob for a note from its text fields. Kept in
-// one place so every write path (transcript, summary, manual edit) produces a
-// consistent index value.
+// one place so every write path (transcript, summary, manual edit, tag edit)
+// produces a consistent index value. Tags are appended so they're searchable.
 export function buildSearchBlob(fields: {
   title?: string
   summary?: string
   transcription?: string
+  tags?: string[]
 }): string {
-  return [fields.title, fields.summary, fields.transcription]
+  return [
+    fields.title,
+    fields.summary,
+    fields.transcription,
+    fields.tags?.join(' '),
+  ]
     .filter((part): part is string => Boolean(part && part.trim().length > 0))
     .join('\n')
 }

--- a/convex/internalMutations.ts
+++ b/convex/internalMutations.ts
@@ -32,6 +32,7 @@ export const saveTranscript = internalMutation({
         title: note?.title,
         summary: note?.summary,
         transcription: transcript,
+        tags: note?.tags,
       }),
     })
 
@@ -76,6 +77,7 @@ export const saveSummary = internalMutation({
         title,
         summary,
         transcription: note.transcription,
+        tags: note.tags,
       }),
     })
 

--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -243,6 +243,7 @@ export const updateNoteFields = mutation({
       title: patch.title ?? note.title,
       summary: patch.summary ?? note.summary,
       transcription: patch.transcription ?? note.transcription,
+      tags: note.tags,
     })
 
     await ctx.db.patch(id, patch)

--- a/convex/organize.ts
+++ b/convex/organize.ts
@@ -1,0 +1,58 @@
+import { v } from 'convex/values'
+import { buildSearchBlob } from './constants'
+import { mutation } from './_generated/server'
+
+// Bounds to keep tag arrays small and the note doc well under Convex's limit.
+const MAX_TAGS = 20
+const MAX_TAG_LENGTH = 40
+
+// Normalizes a raw tag list: trims, drops blanks, caps length, de-dupes
+// case-insensitively (keeping first-seen casing), and caps the count.
+function normalizeTags(tags: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const raw of tags) {
+    const tag = raw.trim().slice(0, MAX_TAG_LENGTH)
+    if (tag.length === 0) continue
+    const key = tag.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(tag)
+    if (result.length >= MAX_TAGS) break
+  }
+  return result
+}
+
+// Replaces a note's tags wholesale. Recomputes searchBlob so tags stay
+// findable via full-text search.
+export const updateNoteTags = mutation({
+  args: {
+    id: v.id('notes'),
+    tags: v.array(v.string()),
+  },
+  handler: async (ctx, { id, tags }) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity) {
+      throw new Error('Not authenticated')
+    }
+
+    const note = await ctx.db.get(id)
+    if (!note) {
+      throw new Error('Note not found')
+    }
+    if (note.userId !== identity.subject) {
+      throw new Error('Not your note')
+    }
+
+    const normalized = normalizeTags(tags)
+    await ctx.db.patch(id, {
+      tags: normalized,
+      searchBlob: buildSearchBlob({
+        title: note.title,
+        summary: note.summary,
+        transcription: note.transcription,
+        tags: normalized,
+      }),
+    })
+  },
+})

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -50,6 +50,9 @@ export default defineSchema({
         v.literal('blog')
       )
     ),
+    // Free-form labels the user attaches for organizing/filtering. Absent on
+    // old notes; UI defaults to []. Folded into searchBlob so tags are findable.
+    tags: v.optional(v.array(v.string())),
   })
     .index('by_userId', ['userId'])
     .index('by_shareId', ['shareId'])

--- a/lib/export.ts
+++ b/lib/export.ts
@@ -1,0 +1,86 @@
+import { type Doc } from '@/convex/_generated/dataModel'
+import { formatDate } from '@/lib/utils'
+
+// Renders a note (plus its action items) as a self-contained Markdown document.
+// Mirrors the shape shown in the app: title, metadata, summary, transcript,
+// action items. Used by the export menu and reused as the file body.
+export function noteToMarkdown(
+  note: Doc<'notes'>,
+  actionItems: Doc<'actionItems'>[]
+): string {
+  const lines: string[] = []
+
+  lines.push(`# ${note.title ?? 'Untitled note'}`)
+  lines.push('')
+
+  const meta: string[] = [formatDate(note._creationTime)]
+  if (note.language) meta.push(`Language: ${note.language}`)
+  if (note.tags && note.tags.length > 0) {
+    meta.push(`Tags: ${note.tags.map((t) => `#${t}`).join(' ')}`)
+  }
+  lines.push(`_${meta.join(' · ')}_`)
+  lines.push('')
+
+  if (note.summary && note.summary.trim().length > 0) {
+    lines.push('## Summary')
+    lines.push('')
+    lines.push(note.summary.trim())
+    lines.push('')
+  }
+
+  const transcriptBody = transcriptToMarkdown(note)
+  if (transcriptBody) {
+    lines.push('## Transcript')
+    lines.push('')
+    lines.push(transcriptBody)
+    lines.push('')
+  }
+
+  if (actionItems.length > 0) {
+    lines.push('## Action items')
+    lines.push('')
+    for (const item of actionItems) {
+      lines.push(`- [ ] ${item.action}`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n').trim() + '\n'
+}
+
+// Prefers the diarized, speaker-labeled transcript when available; otherwise
+// falls back to the plain transcription. Returns '' when there's nothing.
+function transcriptToMarkdown(note: Doc<'notes'>): string {
+  if (note.utterances && note.utterances.length > 0) {
+    return note.utterances
+      .map((u) => `**${u.speaker}:** ${u.text}`)
+      .join('\n\n')
+  }
+  return note.transcription?.trim() ?? ''
+}
+
+// Turns a title into a safe, lowercase filename slug.
+function slugify(title: string | undefined): string {
+  const base = (title ?? 'note')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return base.length > 0 ? base : 'note'
+}
+
+// Triggers a client-side download of the note as a .md file.
+export function downloadNoteMarkdown(
+  note: Doc<'notes'>,
+  actionItems: Doc<'actionItems'>[]
+): void {
+  const markdown = noteToMarkdown(note, actionItems)
+  const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = `${slugify(note.title)}.md`
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## P4 — Organize & export

Final roadmap phase. Stacked on #8 (P3). Two leaf features: lightweight organizing with **tags**, and getting notes out via **Markdown + print-PDF**. No pipeline changes.

> **Folders deferred.** The plan included tags *and* folders, but the inline folder picker felt half-baked, so folders are intentionally left out of this PR. They'll be reimplemented later as a **Notion-style sidebar** rather than a per-note dropdown. No folder schema/backend is shipped, so there's nothing to migrate away from.

### 🏷️ Tags
- **Schema:** `notes` gains `tags: string[]` (optional → backward-compat). Tags are folded into `searchBlob`, so they're findable from the existing full-text search.
- **`convex/organize.ts`:** `updateNoteTags` — owner-guarded; trims, de-dupes case-insensitively, caps count/length.
- **Detail page** (`NoteOrganize`): inline tag editor — type + Enter/comma to add, × or Backspace to remove.
- **Recordings table:** new **Tags** column + a **tag filter** dropdown (matches any selected tag, OR semantics).

### 📤 Export
- **Markdown:** `lib/export.ts` `noteToMarkdown(note, actionItems)` → client-side `.md` download (title, metadata, summary, diarized-or-plain transcript, action items as a checklist).
- **PDF:** `ExportMenu` → **Print / Save as PDF** calls `window.print()`. A dedicated `PrintableNote` (print-only) plus `@media print` rules hide the app chrome, so the output is a clean single-page document instead of fighting the tabbed UI. No new dependency.

### Backward-compat
`tags` is `v.optional` → no migration; old notes default to `tags: []` and render fine.

### Verification
✅ `tsc --noEmit` and `next build` pass. `npx convex codegen` accepts the schema.
Manual: add/remove tags → searchable + filterable in the table; Markdown downloads; Print produces a clean PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
