### PR TITLE
Unify app typography on a single typeface (Inter)

### DIFF
--- a/app/(dashboard)/record/page.tsx
+++ b/app/(dashboard)/record/page.tsx
@@ -143,13 +143,13 @@ export default function RecordPage() {
       <h1 className="text-3xl font-medium tracking-tight sm:text-4xl">
         {STATE_LABEL[state]}
       </h1>
-      <p className="mt-2 font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">
+      <p className="mt-2 font-sans text-xs uppercase tracking-[0.15em] text-muted-foreground">
         {getCurrentFormattedDate()}
       </p>
 
       {state === 'idle' && (
         <div className="mt-8 w-full max-w-xs space-y-1.5">
-          <label className="font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">
+          <label className="font-sans text-xs uppercase tracking-[0.15em] text-muted-foreground">
             Summary style
           </label>
           <Select
@@ -181,7 +181,7 @@ export default function RecordPage() {
             }`}
           />
           <div className="absolute flex h-[88%] w-[88%] items-center justify-center rounded-full bg-background">
-            <span className="font-mono text-5xl font-semibold tabular-nums sm:text-6xl">
+            <span className="font-sans text-5xl font-semibold tabular-nums sm:text-6xl">
               {formatTime(Math.floor(totalSeconds / 60))}:
               {formatTime(totalSeconds % 60)}
             </span>

--- a/app/(dashboard)/recordings/[recordingId]/_components/audio-player.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/audio-player.tsx
@@ -74,7 +74,7 @@ export const AudioPlayer = forwardRef<HTMLAudioElement, AudioPlayerProps>(
             aria-label="Seek"
             className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
           />
-          <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+          <span className="shrink-0 font-sans text-xs tabular-nums text-muted-foreground">
             {formatDuration(currentTime)} / {formatDuration(duration)}
           </span>
         </div>

--- a/app/(dashboard)/recordings/[recordingId]/_components/note-card.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/note-card.tsx
@@ -52,14 +52,14 @@ export default function NoteCard({
             {source === 'ai' && (
               <Badge
                 variant="secondary"
-                className="shrink-0 gap-1 font-mono text-[10px] uppercase tracking-[0.1em]"
+                className="shrink-0 gap-1 font-sans text-[10px] uppercase tracking-[0.1em]"
               >
                 <Sparkles className="h-3 w-3 text-primary" />
                 AI
               </Badge>
             )}
           </div>
-          <p className="font-mono text-xs uppercase tracking-[0.1em] text-muted-foreground">
+          <p className="font-sans text-xs uppercase tracking-[0.1em] text-muted-foreground">
             {title ? `${title} · ` : ''}
             {formatDate(_creationTime)}
           </p>

--- a/app/(dashboard)/recordings/[recordingId]/_components/note-organize.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/note-organize.tsx
@@ -56,7 +56,7 @@ function TagEditor({ noteId, tags }: { noteId: Id<'notes'>; tags: string[] }) {
 
   return (
     <div className="min-w-0 space-y-2">
-      <p className="flex items-center gap-1.5 font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+      <p className="flex items-center gap-1.5 font-sans text-xs uppercase tracking-[0.12em] text-muted-foreground">
         <Tag className="h-3.5 w-3.5" />
         Tags
       </p>

--- a/app/(dashboard)/recordings/[recordingId]/_components/transcript-view.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/_components/transcript-view.tsx
@@ -69,13 +69,13 @@ export function TranscriptView({ utterances, audioRef }: TranscriptViewProps) {
             <div className="flex w-16 shrink-0 flex-col items-start gap-1">
               <span
                 className={cn(
-                  'rounded-full px-2 py-0.5 font-mono text-[11px] font-medium uppercase tracking-wide',
+                  'rounded-full px-2 py-0.5 font-sans text-[11px] font-medium uppercase tracking-wide',
                   speakerColor(u.speaker)
                 )}
               >
                 {u.speaker}
               </span>
-              <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+              <span className="font-sans text-[11px] tabular-nums text-muted-foreground">
                 {formatDuration(u.start / 1000)}
               </span>
             </div>

--- a/app/(dashboard)/recordings/[recordingId]/page.tsx
+++ b/app/(dashboard)/recordings/[recordingId]/page.tsx
@@ -74,7 +74,7 @@ export default function RecordingIdPage() {
             <div className="flex flex-wrap items-center gap-2">
               <StatusBadge status={status} />
               {note.language && (
-                <Badge variant="outline" className="font-mono uppercase">
+                <Badge variant="outline" className="font-sans uppercase">
                   {note.language}
                 </Badge>
               )}

--- a/app/(dashboard)/recordings/_components/columns.tsx
+++ b/app/(dashboard)/recordings/_components/columns.tsx
@@ -32,7 +32,7 @@ function SortableHeader({
   return (
     <Button
       variant="ghost"
-      className="-ml-3 h-8 font-mono text-xs font-medium uppercase tracking-[0.15em] text-muted-foreground hover:text-foreground data-[state=open]:bg-accent"
+      className="-ml-3 h-8 font-sans text-xs font-medium uppercase tracking-[0.15em] text-muted-foreground hover:text-foreground data-[state=open]:bg-accent"
       onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
     >
       {title}
@@ -43,7 +43,7 @@ function SortableHeader({
 
 function HeaderLabel({ children }: { children: React.ReactNode }) {
   return (
-    <span className="font-mono text-xs font-medium uppercase tracking-[0.15em] text-muted-foreground">
+    <span className="font-sans text-xs font-medium uppercase tracking-[0.15em] text-muted-foreground">
       {children}
     </span>
   )
@@ -56,7 +56,7 @@ export const columns: ColumnDef<NoteRow>[] = [
     cell: ({ row }) => {
       const title = row.original.title
       return (
-        <span className="block max-w-[420px] truncate font-display text-[15px] font-medium tracking-tight">
+        <span className="block max-w-[420px] truncate font-sans text-[15px] font-medium tracking-tight">
           {title ?? <span className="text-muted-foreground">Processing…</span>}
         </span>
       )
@@ -82,7 +82,7 @@ export const columns: ColumnDef<NoteRow>[] = [
             <Badge
               key={tag}
               variant="secondary"
-              className="font-mono text-[10px] uppercase tracking-[0.08em]"
+              className="font-sans text-[10px] uppercase tracking-[0.08em]"
             >
               {tag}
             </Badge>
@@ -108,7 +108,7 @@ export const columns: ColumnDef<NoteRow>[] = [
     accessorKey: '_creationTime',
     header: ({ column }) => <SortableHeader column={column} title="Date" />,
     cell: ({ row }) => (
-      <span className="font-mono text-xs text-muted-foreground">
+      <span className="font-sans text-xs text-muted-foreground">
         {formatDate(row.getValue('_creationTime'))}
       </span>
     ),

--- a/app/(dashboard)/recordings/_components/data-table.tsx
+++ b/app/(dashboard)/recordings/_components/data-table.tsx
@@ -188,7 +188,7 @@ export function DataTable<TData, TValue>({
       </div>
 
       <div className="flex items-center justify-between">
-        <p className="font-mono text-xs uppercase tracking-[0.12em] text-muted-foreground">
+        <p className="font-sans text-xs uppercase tracking-[0.12em] text-muted-foreground">
           {table.getFilteredRowModel().rows.length} note
           {table.getFilteredRowModel().rows.length === 1 ? '' : 's'}
         </p>

--- a/app/(dashboard)/search/page.tsx
+++ b/app/(dashboard)/search/page.tsx
@@ -76,7 +76,7 @@ export default function SearchPage() {
                       <FileText className="h-4 w-4" />
                     </span>
                     <div className="min-w-0 space-y-1">
-                      <p className="truncate font-display text-[15px] font-medium">
+                      <p className="truncate font-sans text-[15px] font-medium">
                         {note.title ?? 'Untitled note'}
                       </p>
                       {note.summary && (
@@ -84,7 +84,7 @@ export default function SearchPage() {
                           {note.summary}
                         </p>
                       )}
-                      <p className="font-mono text-xs uppercase tracking-[0.1em] text-muted-foreground">
+                      <p className="font-sans text-xs uppercase tracking-[0.1em] text-muted-foreground">
                         {formatDate(note._creationTime)}
                       </p>
                     </div>

--- a/app/(marketing)/_component/bento-grid.tsx
+++ b/app/(marketing)/_component/bento-grid.tsx
@@ -44,7 +44,7 @@ export const BentoGridItem = ({
         <div className="flex h-9 w-9 items-center justify-center rounded-lg border bg-muted/50 text-primary">
           {icon}
         </div>
-        <div className="mb-1.5 mt-3 font-display text-lg font-semibold tracking-tight text-foreground">
+        <div className="mb-1.5 mt-3 font-sans text-lg font-semibold tracking-tight text-foreground">
           {title}
         </div>
         <div className="text-sm font-normal leading-relaxed text-muted-foreground">

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -31,7 +31,7 @@ export default function MarketingPage() {
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
               <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-primary" />
             </span>
-            <span className="font-mono text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            <span className="font-sans text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
               AI voice notes
             </span>
           </span>
@@ -82,7 +82,7 @@ export default function MarketingPage() {
           </div>
 
           <p
-            className="mt-5 animate-fade-up font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground opacity-0"
+            className="mt-5 animate-fade-up font-sans text-xs uppercase tracking-[0.15em] text-muted-foreground opacity-0"
             style={{ animationDelay: '0.45s', animationFillMode: 'forwards' }}
           >
             Free forever · No credit card · Open source
@@ -98,7 +98,7 @@ export default function MarketingPage() {
                 <span className="h-3 w-3 rounded-full bg-destructive/50" />
                 <span className="h-3 w-3 rounded-full bg-warning/60" />
                 <span className="h-3 w-3 rounded-full bg-success/50" />
-                <span className="ml-3 font-mono text-xs text-muted-foreground">
+                <span className="ml-3 font-sans text-xs text-muted-foreground">
                   notesgpt — dashboard
                 </span>
               </div>
@@ -137,7 +137,7 @@ export default function MarketingPage() {
               >
                 <div className="flex items-center justify-between">
                   <step.icon className="h-5 w-5 text-primary" />
-                  <span className="font-mono text-xs text-muted-foreground">
+                  <span className="font-sans text-xs text-muted-foreground">
                     {step.step}
                   </span>
                 </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -133,7 +133,7 @@
   h2,
   h3,
   h4 {
-    @apply font-display tracking-tight;
+    @apply font-sans tracking-tight;
     font-feature-settings: 'ss01' 1;
   }
   ::selection {
@@ -148,7 +148,7 @@
 
   /* Editorial eyebrow — uppercase mono label */
   .eyebrow {
-    @apply font-mono text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground;
+    @apply font-sans text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground;
   }
 
   /* Subtle blueprint grid background */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css'
 import { Toaster } from 'sonner'
 import { type Metadata } from 'next'
-import { Inter, Fraunces, JetBrains_Mono } from 'next/font/google'
+import { Inter } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react'
 import { ThemeProvider } from '@/components/theme-provider'
 import { ConvexProvider } from '@/components/providers/convex-provider'
@@ -9,25 +9,14 @@ import { ConvexProvider } from '@/components/providers/convex-provider'
 import Navbar from '@/components/navbar'
 import Footer from '@/components/footer'
 
+// Single typeface for the entire app — clean, premium, and built for screens.
+// Inter powers body, headings, and labels alike; hierarchy comes from weight,
+// size, and letter-spacing rather than from switching font families.
 const fontSans = Inter({
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
-  variable: '--font-sans',
-})
-
-// Editorial serif for display headings — high-contrast, with italics for accents.
-const fontDisplay = Fraunces({
-  subsets: ['latin'],
-  weight: ['400', '500', '600', '700'],
   style: ['normal', 'italic'],
-  variable: '--font-display',
-})
-
-// Monospace for eyebrows, captions and terminal-style UI.
-const fontMono = JetBrains_Mono({
-  subsets: ['latin'],
-  weight: ['400', '500', '600'],
-  variable: '--font-mono',
+  variable: '--font-sans',
 })
 
 export const metadata: Metadata = {
@@ -92,7 +81,7 @@ export default function RootLayout({
     <ConvexProvider>
       <html
         lang="en"
-        className={`${fontSans.variable} ${fontDisplay.variable} ${fontMono.variable}`}
+        className={fontSans.variable}
       >
         <body className="font-sans antialiased">
           <ThemeProvider

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -114,7 +114,7 @@ export function ChatPanel({
                       <Link
                         key={id}
                         href={`/recordings/${id}`}
-                        className="inline-flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+                        className="inline-flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 font-sans text-[11px] text-muted-foreground transition-colors hover:text-foreground"
                       >
                         <FileText className="h-3 w-3" />
                         Source {i + 1}

--- a/components/empty-state.tsx
+++ b/components/empty-state.tsx
@@ -32,7 +32,7 @@ export function EmptyState({
           <Icon className="h-6 w-6" />
         </span>
       )}
-      <h3 className="relative font-display text-xl font-semibold tracking-tight">
+      <h3 className="relative font-sans text-xl font-semibold tracking-tight">
         {title}
       </h3>
       {description && (

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -30,7 +30,7 @@ export default function Footer() {
               GitHub
             </a>
           </nav>
-          <p className="font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">
+          <p className="font-sans text-xs uppercase tracking-[0.15em] text-muted-foreground">
             © 2026 NotesGPT · Open source
           </p>
         </div>

--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -35,7 +35,7 @@ export function Logo({ className, href = '/', showWordmark = true }: LogoProps) 
     >
       <LogoMark />
       {showWordmark && (
-        <span className="font-display text-xl font-semibold tracking-tight">
+        <span className="font-sans text-xl font-semibold tracking-tight">
           NotesGPT
         </span>
       )}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,10 +19,9 @@ const config = {
     },
     extend: {
       fontFamily: {
+        // One typeface across the whole app: Inter. Hierarchy comes from
+        // weight, size, and letter-spacing — not from switching families.
         sans: ["var(--font-sans)", "ui-sans-serif", "system-ui", "sans-serif"],
-        display: ["var(--font-display)", "ui-serif", "Georgia", "serif"],
-        serif: ["var(--font-display)", "ui-serif", "Georgia", "serif"],
-        mono: ["var(--font-mono)", "ui-monospace", "SFMono-Regular", "monospace"],
       },
       colors: {
         border: "hsl(var(--border))",


### PR DESCRIPTION
## Summary

Unifies the app on a **single typeface — Inter** — replacing the previous mix of three fonts that read as inconsistent across the UI.

Before, the app used:
- **Inter** for body text
- **Fraunces** (serif) for display headings
- **JetBrains Mono** for eyebrows, badges, captions, and the recording timer

Now everything uses **Inter**, chosen for a clean, premium, screen-first feel. Visual hierarchy (uppercase labels, bold headings, tabular timer) is preserved through **weight, size, and letter-spacing** rather than switching font families.

## Changes
- **`app/layout.tsx`** — load only Inter (weights 400–700 + italics); remove the Fraunces and JetBrains Mono imports.
- **`tailwind.config.ts`** — collapse the `sans`/`display`/`serif`/`mono` families down to a single `sans` alias pointing at Inter.
- **Components / pages / `globals.css`** — rename every `font-display` and `font-mono` class usage to `font-sans` so the codebase reads consistently.

## Notes
- No functional/behavior changes — purely typographic.
- Dropping two web fonts also trims page weight.
- `tsc --noEmit` passes; print/PDF export and the public share page inherit Inter too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
